### PR TITLE
Fix glob pattern bug in pipeline command

### DIFF
--- a/src/docs2db/docs2db.py
+++ b/src/docs2db/docs2db.py
@@ -693,7 +693,7 @@ def pipeline(
         logger.info("[3/7] Generating chunks...")
         if not generate_chunks(
             content_dir=content_dir,
-            pattern="**/*.json",
+            pattern="**",
             force=False,
             dry_run=False,
             skip_context=skip_context,
@@ -710,7 +710,7 @@ def pipeline(
         if not generate_embeddings(
             content_dir=content_dir,
             model=model,
-            pattern="**/*.chunks.json",
+            pattern="**",
             force=False,
             dry_run=False,
         ):
@@ -722,7 +722,7 @@ def pipeline(
             load_documents(
                 content_dir=content_dir,
                 model=model,
-                pattern="**/*.json",
+                pattern="**",
                 host=None,
                 port=None,
                 db=None,


### PR DESCRIPTION
### Summary
Change patterns from `**/*.json` to `**` to match the correct file structure. The functions append `/source.json` or `/chunks.json` to the pattern, so `**/*.json/source.json` was failing to find files.

Fixes #3 

**Before**: No source files found matching pattern: `**/*.json/source.json`
**After**:  11 files chunked successfully

Fixes chunking, embedding, and loading in the pipeline.