### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything
+*   @rhel-lightspeed/developers


### PR DESCRIPTION
Add `.github/CODEOWNERS` with `@rhel-lightspeed/developers` as the default owner for all paths. This enforces the org-level `require_code_owner_review` branch protection rule, which is currently a no-op on repos without a CODEOWNERS file.

Ref: RSPEED-2473