### PR TITLE
fix(tests): fix dead force test and remove broad exception swallowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed document path mismatch in up-to-date check — skip-check now uses relative paths matching DB storage, preventing unnecessary re-processing
 - Added per-document savepoint isolation in batch loading — one failed document no longer aborts the entire batch transaction
+- Fixed `test_load_documents_force_parameter` — test now uses correct fixture layout and exercises both force=False (skip) and force=True (reload) paths
+- Fixed `test_load_documents_parameter_validation` — removed broad exception swallowing that masked real failures
+- Fixed `test_database_functions_interface` — removed vacuous assertion (check_database_status returns None by contract)
 
 ### Changed
 - Converted database layer from async psycopg (`AsyncConnection`) to sync psycopg (`Connection`), eliminating nested event loop issues with single-threaded batch processing

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,6 +1,5 @@
 """Tests for database operations."""
 
-import json
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -109,49 +108,60 @@ class TestDatabaseSQL:
     def test_load_documents_force_parameter(self):
         """Test the force parameter in load_documents."""
         if should_skip_postgres_tests():
-            pytest.skip("PostgreSQL tests are disabled (TEST_SKIP_POSTGRES=1)")
+            pytest.skip("PostgreSQL tests are disabled")
 
         config = get_test_db_config()
+        content_dir = str(Path(__file__).parent / "fixtures" / "content" / "documents")
 
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # Create a simple JSON file
-            test_file = Path(temp_dir) / "test.json"
-            test_data = {
-                "name": "test_doc",
-                "origin": {"filename": "test.json"},
-                "texts": [{"text": "This is a test document."}],
-            }
-            test_file.write_text(json.dumps(test_data, indent=2))
+        # First load — should process the document
+        success1 = load_documents(
+            content_dir=content_dir,
+            model="ibm-granite/granite-embedding-30m-english",
+            pattern="**",
+            host=config["host"],
+            port=int(config["port"]),
+            db=config["database"],
+            user=config["user"],
+            password=config["password"],
+            force=False,
+        )
+        assert success1 is True
 
-            # Test with force=False
-            success1 = load_documents(
-                content_dir=temp_dir,
-                model="ibm-granite/granite-embedding-30m-english",
-                pattern="**",
-                host=config["host"],
-                port=int(config["port"]),
-                db=config["database"],
-                user=config["user"],
-                password=config["password"],
-                force=False,
-            )
+        # Verify document was actually loaded (not just "no files to process")
+        conn = create_connection()
+        with conn:
+            result = conn.execute("SELECT COUNT(*) FROM documents")
+            doc_count = result.fetchone()[0]
+        conn.close()
+        assert doc_count > 0, "First load should insert at least one document"
 
-            # Test with force=True
-            success2 = load_documents(
-                content_dir=temp_dir,
-                model="ibm-granite/granite-embedding-30m-english",
-                pattern="**",
-                host=config["host"],
-                port=int(config["port"]),
-                db=config["database"],
-                user=config["user"],
-                password=config["password"],
-                force=True,
-            )
+        # Second load with force=False — should skip (documents already loaded)
+        success2 = load_documents(
+            content_dir=content_dir,
+            model="ibm-granite/granite-embedding-30m-english",
+            pattern="**",
+            host=config["host"],
+            port=int(config["port"]),
+            db=config["database"],
+            user=config["user"],
+            password=config["password"],
+            force=False,
+        )
+        assert success2 is True
 
-            # Both should return boolean values
-            assert isinstance(success1, bool)
-            assert isinstance(success2, bool)
+        # Third load with force=True — should re-process (forced reload)
+        success3 = load_documents(
+            content_dir=content_dir,
+            model="ibm-granite/granite-embedding-30m-english",
+            pattern="**",
+            host=config["host"],
+            port=int(config["port"]),
+            db=config["database"],
+            user=config["user"],
+            password=config["password"],
+            force=True,
+        )
+        assert success3 is True
 
     def test_database_tables_after_load(self):
         """Test that expected tables exist after load attempt."""
@@ -207,24 +217,19 @@ class TestDatabaseSQL:
         config = get_test_db_config()
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            # Test with valid parameters
-            try:
-                success = load_documents(
-                    content_dir=temp_dir,
-                    model="ibm-granite/granite-embedding-30m-english",
-                    pattern="**",
-                    host=config["host"],
-                    port=int(config["port"]),
-                    db=config["database"],
-                    user=config["user"],
-                    password=config["password"],
-                    force=False,
-                    batch_size=50,  # Test optional parameter
-                )
-                assert isinstance(success, bool)
-            except Exception:
-                # Schema issues are acceptable for this interface test
-                pass
+            result = load_documents(
+                content_dir=temp_dir,
+                model="ibm-granite/granite-embedding-30m-english",
+                pattern="**",
+                host=config["host"],
+                port=int(config["port"]),
+                db=config["database"],
+                user=config["user"],
+                password=config["password"],
+                force=False,
+                batch_size=50,
+            )
+            assert result is True
 
     def test_connection_error_handling(self):
         """Test connection error handling."""
@@ -264,7 +269,8 @@ class TestDatabaseSQL:
                 password=config["password"],
             )
 
-        result = check_database_status(
+        # check_database_status raises DatabaseError on failure; completing without exception IS the assertion
+        check_database_status(
             host=config["host"],
             port=int(config["port"]),
             db=config["database"],
@@ -272,276 +278,4 @@ class TestDatabaseSQL:
             password=config["password"],
         )
 
-        assert result is None
-
     def test_savepoint_isolation_partial_batch_failure(self):
-        """Test that savepoint isolation allows partial batch success.
-
-        When one document in a batch fails during the DB insertion phase,
-        the SAVEPOINT/ROLLBACK TO SAVEPOINT mechanism catches the error for
-        that document only, allowing the other documents in the batch to
-        succeed. This verifies the per-document savepoint/rollback logic
-        in load_document_batch.
-        """
-        if should_skip_postgres_tests():
-            pytest.skip("PostgreSQL tests are disabled (TEST_SKIP_POSTGRES=1)")
-
-        fixtures_dir = Path(__file__).parent / "fixtures" / "content" / "documents"
-        if not fixtures_dir.exists():
-            pytest.skip("Test fixtures not available")
-
-        config = get_test_db_config()
-        db_manager = DatabaseManager(
-            host=config["host"],
-            port=int(config["port"]),
-            database=config["database"],
-            user=config["user"],
-            password=config["password"],
-        )
-        db_manager.initialize_schema()
-
-        good_path = "good_doc/source.json"
-        bad_path = "bad_doc/source.json"
-
-        with tempfile.TemporaryDirectory() as temp_dir:
-            content_dir = Path(temp_dir)
-
-            # --- Good document: will succeed ---
-            good_dir = content_dir / "good_doc"
-            good_dir.mkdir()
-            good_source = good_dir / "source.json"
-            good_source.write_text(
-                json.dumps({"title": "Good Doc", "content": "Content."})
-            )
-            good_chunks_file = good_dir / "chunks.json"
-            good_chunks_file.write_text(
-                json.dumps({
-                    "chunks": [
-                        {
-                            "text": "Good document text for savepoint test.",
-                            "contextual_text": "Good document text for savepoint test.",
-                            "metadata": {"chunk_index": 0},
-                        }
-                    ],
-                    "model": "ibm-granite/granite-embedding-30m-english",
-                })
-            )
-            good_embedding_data = {"embeddings": [[0.1] * 384]}
-            good_emb_file = good_dir / "gran.json"
-            good_emb_file.write_text(json.dumps(good_embedding_data))
-
-            # --- Bad document: will fail during INSERT ---
-            bad_dir = content_dir / "bad_doc"
-            bad_dir.mkdir()
-            bad_source = bad_dir / "source.json"
-            bad_source.write_text(
-                json.dumps({"title": "Bad Doc", "content": "Content."})
-            )
-            bad_chunks_file = bad_dir / "chunks.json"
-            bad_chunks_file.write_text(
-                json.dumps({
-                    "chunks": [
-                        {
-                            "text": "Bad document text for savepoint test.",
-                            "contextual_text": "Bad document text for savepoint test.",
-                            "metadata": {"chunk_index": 0},
-                        }
-                    ],
-                    "model": "ibm-granite/granite-embedding-30m-english",
-                })
-            )
-            bad_embedding_data = {"embeddings": [[0.1] * 384]}
-            bad_emb_file = bad_dir / "gran.json"
-            bad_emb_file.write_text(json.dumps(bad_embedding_data))
-
-            model = "ibm-granite/granite-embedding-30m-english"
-            files_data = [
-                (
-                    good_source,
-                    good_chunks_file,
-                    model,
-                    good_embedding_data,
-                    good_emb_file,
-                ),
-                (
-                    bad_source,
-                    bad_chunks_file,
-                    model,
-                    bad_embedding_data,
-                    bad_emb_file,
-                ),
-            ]
-
-            # Connection wrapper that simulates a DB failure for the bad_doc
-            # INSERT while letting all other operations (including SAVEPOINT
-            # commands, which use Composed SQL objects) pass through normally.
-            original_get_conn = db_manager.get_direct_connection
-            call_count = [0]
-
-            class _FailOnBadDoc:
-                """Wraps a real DB connection, raising on INSERT for 'bad_doc'."""
-
-                def __init__(self, conn):
-                    self._conn = conn
-
-                def execute(self, sql, params=None, *args, **kwargs):
-                    if (
-                        isinstance(sql, str)
-                        and "INSERT INTO documents" in sql
-                        and params
-                        and "bad_doc" in str(params[0])
-                    ):
-                        raise RuntimeError(
-                            "Simulated DB failure for savepoint isolation test"
-                        )
-                    return self._conn.execute(sql, params, *args, **kwargs)
-
-                def commit(self):
-                    return self._conn.commit()
-
-                def rollback(self):
-                    return self._conn.rollback()
-
-                def __enter__(self):
-                    self._conn.__enter__()
-                    return self
-
-                def __exit__(self, *args):
-                    return self._conn.__exit__(*args)
-
-            def mock_get_conn():
-                call_count[0] += 1
-                conn = original_get_conn()
-                # First call is for insert_model; wrap only the bulk-ops call
-                return _FailOnBadDoc(conn) if call_count[0] > 1 else conn
-
-            try:
-                with patch.object(
-                    db_manager,
-                    "get_direct_connection",
-                    side_effect=mock_get_conn,
-                ):
-                    processed, errors = db_manager.load_document_batch(
-                        files_data, content_dir, force=True
-                    )
-
-                # Partial success: good_doc processed, bad_doc errored
-                assert processed > 0, (
-                    f"Expected at least one document processed, got {processed}"
-                )
-                assert errors > 0, f"Expected at least one error, got {errors}"
-
-                # The successful document must be in the database
-                with create_connection() as conn:
-                    with conn.cursor() as cur:
-                        cur.execute(
-                            "SELECT path FROM documents WHERE path = %s",
-                            (good_path,),
-                        )
-                        assert cur.fetchone() is not None, (
-                            f"Good document '{good_path}' not found in documents table"
-                        )
-            finally:
-                # Clean up test documents
-                with create_connection() as conn:
-                    conn.execute(
-                        "DELETE FROM documents WHERE path IN (%s, %s)",
-                        (good_path, bad_path),
-                    )
-                    conn.commit()
-
-    def test_skip_check_uses_relative_path(self):
-        """Test that the up-to-date check matches DB paths correctly.
-
-        The skip-check query (force=False path) must compare against the
-        document's relative path — the same format stored in the documents
-        table.  Before the fix, it compared absolute paths, so the query
-        never matched and every document was needlessly re-processed.
-
-        Verifies the fix by loading a document once (force=True), then
-        re-loading with force=False and asserting it is skipped.
-        """
-        if should_skip_postgres_tests():
-            pytest.skip("PostgreSQL tests are disabled (TEST_SKIP_POSTGRES=1)")
-
-        config = get_test_db_config()
-        db_manager = DatabaseManager(
-            host=config["host"],
-            port=int(config["port"]),
-            database=config["database"],
-            user=config["user"],
-            password=config["password"],
-        )
-        db_manager.initialize_schema()
-
-        doc_rel_path = "skipcheck_doc/source.json"
-
-        with tempfile.TemporaryDirectory() as temp_dir:
-            content_dir = Path(temp_dir)
-
-            # Create a single document with chunk + embedding
-            doc_dir = content_dir / "skipcheck_doc"
-            doc_dir.mkdir()
-            source = doc_dir / "source.json"
-            source.write_text(
-                json.dumps({"title": "Skip Check Doc", "content": "Content."})
-            )
-            chunks_file = doc_dir / "chunks.json"
-            chunks_file.write_text(
-                json.dumps({
-                    "chunks": [
-                        {
-                            "text": "Text for skip-check path test.",
-                            "contextual_text": "Text for skip-check path test.",
-                            "metadata": {"chunk_index": 0},
-                        }
-                    ],
-                    "model": "ibm-granite/granite-embedding-30m-english",
-                })
-            )
-            embedding_data = {"embeddings": [[0.1] * 384]}
-            emb_file = doc_dir / "gran.json"
-            emb_file.write_text(json.dumps(embedding_data))
-
-            model = "ibm-granite/granite-embedding-30m-english"
-            files_data = [
-                (source, chunks_file, model, embedding_data, emb_file),
-            ]
-
-            try:
-                # --- First load: force=True inserts the document ---
-                processed_1, errors_1 = db_manager.load_document_batch(
-                    files_data, content_dir, force=True
-                )
-                assert errors_1 == 0, f"First load had unexpected errors: {errors_1}"
-                assert processed_1 == 1, (
-                    f"Expected 1 document processed on first load, got {processed_1}"
-                )
-
-                # Verify the document is stored with a relative path
-                with create_connection() as conn:
-                    with conn.cursor() as cur:
-                        cur.execute(
-                            "SELECT path FROM documents WHERE path = %s",
-                            (doc_rel_path,),
-                        )
-                        assert cur.fetchone() is not None, (
-                            f"Document not found at relative path '{doc_rel_path}'"
-                        )
-
-                # --- Second load: force=False should skip (already up to date) ---
-                processed_2, errors_2 = db_manager.load_document_batch(
-                    files_data, content_dir, force=False
-                )
-                assert errors_2 == 0, f"Second load had unexpected errors: {errors_2}"
-                assert processed_2 == 0, (
-                    f"Expected 0 documents processed (skip), got {processed_2}. "
-                    "The up-to-date check likely failed to match the relative path."
-                )
-            finally:
-                with create_connection() as conn:
-                    conn.execute(
-                        "DELETE FROM documents WHERE path = %s",
-                        (doc_rel_path,),
-                    )
-                    conn.commit()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -115,6 +115,11 @@ class TestDatabaseSQL:
         if not Path(content_dir).exists():
             pytest.skip("Test fixtures not available")
 
+        with create_connection() as conn:
+            doc_count_before = conn.execute(
+                "SELECT COUNT(*) FROM documents"
+            ).fetchone()[0]
+
         # First load — should process the document
         success1 = load_documents(
             content_dir=content_dir,
@@ -129,10 +134,13 @@ class TestDatabaseSQL:
         )
         assert success1 is True
 
-        # Verify document was actually loaded (not just "no files to process")
         with create_connection() as conn:
-            doc_count = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
-        assert doc_count > 0, "First load should insert at least one document"
+            doc_count_after = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[
+                0
+            ]
+        assert doc_count_after > doc_count_before, (
+            "First load should insert at least one document"
+        )
 
         # Second load with force=False — should skip (documents already loaded)
         success2 = load_documents(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -112,6 +112,8 @@ class TestDatabaseSQL:
 
         config = get_test_db_config()
         content_dir = str(Path(__file__).parent / "fixtures" / "content" / "documents")
+        if not Path(content_dir).exists():
+            pytest.skip("Test fixtures not available")
 
         # First load — should process the document
         success1 = load_documents(
@@ -128,11 +130,8 @@ class TestDatabaseSQL:
         assert success1 is True
 
         # Verify document was actually loaded (not just "no files to process")
-        conn = create_connection()
-        with conn:
-            result = conn.execute("SELECT COUNT(*) FROM documents")
-            doc_count = result.fetchone()[0]
-        conn.close()
+        with create_connection() as conn:
+            doc_count = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
         assert doc_count > 0, "First load should insert at least one document"
 
         # Second load with force=False — should skip (documents already loaded)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -160,6 +160,14 @@ class TestDatabaseSQL:
         )
         assert success2 is True
 
+        with create_connection() as conn:
+            doc_count_after_skip = conn.execute(
+                "SELECT COUNT(*) FROM documents"
+            ).fetchone()[0]
+        assert doc_count_after_skip == doc_count_after, (
+            "force=False should not insert additional documents"
+        )
+
         # Third load with force=True — should re-process (forced reload)
         success3 = load_documents(
             content_dir=content_dir,

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,5 +1,6 @@
 """Tests for database operations."""
 
+import json
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -115,10 +116,13 @@ class TestDatabaseSQL:
         if not Path(content_dir).exists():
             pytest.skip("Test fixtures not available")
 
-        with create_connection() as conn:
-            doc_count_before = conn.execute(
-                "SELECT COUNT(*) FROM documents"
-            ).fetchone()[0]
+        try:
+            with create_connection() as conn:
+                doc_count_before = conn.execute(
+                    "SELECT COUNT(*) FROM documents"
+                ).fetchone()[0]
+        except psycopg.errors.UndefinedTable:
+            doc_count_before = 0
 
         # First load — should process the document
         success1 = load_documents(
@@ -286,3 +290,273 @@ class TestDatabaseSQL:
         )
 
     def test_savepoint_isolation_partial_batch_failure(self):
+        """Test that savepoint isolation allows partial batch success.
+
+        When one document in a batch fails during the DB insertion phase,
+        the SAVEPOINT/ROLLBACK TO SAVEPOINT mechanism catches the error for
+        that document only, allowing the other documents in the batch to
+        succeed. This verifies the per-document savepoint/rollback logic
+        in load_document_batch.
+        """
+        if should_skip_postgres_tests():
+            pytest.skip("PostgreSQL tests are disabled (TEST_SKIP_POSTGRES=1)")
+
+        fixtures_dir = Path(__file__).parent / "fixtures" / "content" / "documents"
+        if not fixtures_dir.exists():
+            pytest.skip("Test fixtures not available")
+
+        config = get_test_db_config()
+        db_manager = DatabaseManager(
+            host=config["host"],
+            port=int(config["port"]),
+            database=config["database"],
+            user=config["user"],
+            password=config["password"],
+        )
+        db_manager.initialize_schema()
+
+        good_path = "good_doc/source.json"
+        bad_path = "bad_doc/source.json"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            content_dir = Path(temp_dir)
+
+            # --- Good document: will succeed ---
+            good_dir = content_dir / "good_doc"
+            good_dir.mkdir()
+            good_source = good_dir / "source.json"
+            good_source.write_text(
+                json.dumps({"title": "Good Doc", "content": "Content."})
+            )
+            good_chunks_file = good_dir / "chunks.json"
+            good_chunks_file.write_text(
+                json.dumps({
+                    "chunks": [
+                        {
+                            "text": "Good document text for savepoint test.",
+                            "contextual_text": "Good document text for savepoint test.",
+                            "metadata": {"chunk_index": 0},
+                        }
+                    ],
+                    "model": "ibm-granite/granite-embedding-30m-english",
+                })
+            )
+            good_embedding_data = {"embeddings": [[0.1] * 384]}
+            good_emb_file = good_dir / "gran.json"
+            good_emb_file.write_text(json.dumps(good_embedding_data))
+
+            # --- Bad document: will fail during INSERT ---
+            bad_dir = content_dir / "bad_doc"
+            bad_dir.mkdir()
+            bad_source = bad_dir / "source.json"
+            bad_source.write_text(
+                json.dumps({"title": "Bad Doc", "content": "Content."})
+            )
+            bad_chunks_file = bad_dir / "chunks.json"
+            bad_chunks_file.write_text(
+                json.dumps({
+                    "chunks": [
+                        {
+                            "text": "Bad document text for savepoint test.",
+                            "contextual_text": "Bad document text for savepoint test.",
+                            "metadata": {"chunk_index": 0},
+                        }
+                    ],
+                    "model": "ibm-granite/granite-embedding-30m-english",
+                })
+            )
+            bad_embedding_data = {"embeddings": [[0.1] * 384]}
+            bad_emb_file = bad_dir / "gran.json"
+            bad_emb_file.write_text(json.dumps(bad_embedding_data))
+
+            model = "ibm-granite/granite-embedding-30m-english"
+            files_data = [
+                (
+                    good_source,
+                    good_chunks_file,
+                    model,
+                    good_embedding_data,
+                    good_emb_file,
+                ),
+                (
+                    bad_source,
+                    bad_chunks_file,
+                    model,
+                    bad_embedding_data,
+                    bad_emb_file,
+                ),
+            ]
+
+            # Connection wrapper that simulates a DB failure for the bad_doc
+            # INSERT while letting all other operations (including SAVEPOINT
+            # commands, which use Composed SQL objects) pass through normally.
+            original_get_conn = db_manager.get_direct_connection
+            call_count = [0]
+
+            class _FailOnBadDoc:
+                """Wraps a real DB connection, raising on INSERT for 'bad_doc'."""
+
+                def __init__(self, conn):
+                    self._conn = conn
+
+                def execute(self, sql, params=None, *args, **kwargs):
+                    if (
+                        isinstance(sql, str)
+                        and "INSERT INTO documents" in sql
+                        and params
+                        and "bad_doc" in str(params[0])
+                    ):
+                        raise RuntimeError(
+                            "Simulated DB failure for savepoint isolation test"
+                        )
+                    return self._conn.execute(sql, params, *args, **kwargs)
+
+                def commit(self):
+                    return self._conn.commit()
+
+                def rollback(self):
+                    return self._conn.rollback()
+
+                def __enter__(self):
+                    self._conn.__enter__()
+                    return self
+
+                def __exit__(self, *args):
+                    return self._conn.__exit__(*args)
+
+            def mock_get_conn():
+                call_count[0] += 1
+                conn = original_get_conn()
+                # First call is for insert_model; wrap only the bulk-ops call
+                return _FailOnBadDoc(conn) if call_count[0] > 1 else conn
+
+            try:
+                with patch.object(
+                    db_manager,
+                    "get_direct_connection",
+                    side_effect=mock_get_conn,
+                ):
+                    processed, errors = db_manager.load_document_batch(
+                        files_data, content_dir, force=True
+                    )
+
+                # Partial success: good_doc processed, bad_doc errored
+                assert processed > 0, (
+                    f"Expected at least one document processed, got {processed}"
+                )
+                assert errors > 0, f"Expected at least one error, got {errors}"
+
+                # The successful document must be in the database
+                with create_connection() as conn:
+                    with conn.cursor() as cur:
+                        cur.execute(
+                            "SELECT path FROM documents WHERE path = %s",
+                            (good_path,),
+                        )
+                        assert cur.fetchone() is not None, (
+                            f"Good document '{good_path}' not found in documents table"
+                        )
+            finally:
+                # Clean up test documents
+                with create_connection() as conn:
+                    conn.execute(
+                        "DELETE FROM documents WHERE path IN (%s, %s)",
+                        (good_path, bad_path),
+                    )
+                    conn.commit()
+
+    def test_skip_check_uses_relative_path(self):
+        """Test that the up-to-date check matches DB paths correctly.
+
+        The skip-check query (force=False path) must compare against the
+        document's relative path — the same format stored in the documents
+        table.  Before the fix, it compared absolute paths, so the query
+        never matched and every document was needlessly re-processed.
+
+        Verifies the fix by loading a document once (force=True), then
+        re-loading with force=False and asserting it is skipped.
+        """
+        if should_skip_postgres_tests():
+            pytest.skip("PostgreSQL tests are disabled (TEST_SKIP_POSTGRES=1)")
+
+        config = get_test_db_config()
+        db_manager = DatabaseManager(
+            host=config["host"],
+            port=int(config["port"]),
+            database=config["database"],
+            user=config["user"],
+            password=config["password"],
+        )
+        db_manager.initialize_schema()
+
+        doc_rel_path = "skipcheck_doc/source.json"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            content_dir = Path(temp_dir)
+
+            # Create a single document with chunk + embedding
+            doc_dir = content_dir / "skipcheck_doc"
+            doc_dir.mkdir()
+            source = doc_dir / "source.json"
+            source.write_text(
+                json.dumps({"title": "Skip Check Doc", "content": "Content."})
+            )
+            chunks_file = doc_dir / "chunks.json"
+            chunks_file.write_text(
+                json.dumps({
+                    "chunks": [
+                        {
+                            "text": "Text for skip-check path test.",
+                            "contextual_text": "Text for skip-check path test.",
+                            "metadata": {"chunk_index": 0},
+                        }
+                    ],
+                    "model": "ibm-granite/granite-embedding-30m-english",
+                })
+            )
+            embedding_data = {"embeddings": [[0.1] * 384]}
+            emb_file = doc_dir / "gran.json"
+            emb_file.write_text(json.dumps(embedding_data))
+
+            model = "ibm-granite/granite-embedding-30m-english"
+            files_data = [
+                (source, chunks_file, model, embedding_data, emb_file),
+            ]
+
+            try:
+                # --- First load: force=True inserts the document ---
+                processed_1, errors_1 = db_manager.load_document_batch(
+                    files_data, content_dir, force=True
+                )
+                assert errors_1 == 0, f"First load had unexpected errors: {errors_1}"
+                assert processed_1 == 1, (
+                    f"Expected 1 document processed on first load, got {processed_1}"
+                )
+
+                # Verify the document is stored with a relative path
+                with create_connection() as conn:
+                    with conn.cursor() as cur:
+                        cur.execute(
+                            "SELECT path FROM documents WHERE path = %s",
+                            (doc_rel_path,),
+                        )
+                        assert cur.fetchone() is not None, (
+                            f"Document not found at relative path '{doc_rel_path}'"
+                        )
+
+                # --- Second load: force=False should skip (already up to date) ---
+                processed_2, errors_2 = db_manager.load_document_batch(
+                    files_data, content_dir, force=False
+                )
+                assert errors_2 == 0, f"Second load had unexpected errors: {errors_2}"
+                assert processed_2 == 0, (
+                    f"Expected 0 documents processed (skip), got {processed_2}. "
+                    "The up-to-date check likely failed to match the relative path."
+                )
+            finally:
+                with create_connection() as conn:
+                    conn.execute(
+                        "DELETE FROM documents WHERE path = %s",
+                        (doc_rel_path,),
+                    )
+                    conn.commit()


### PR DESCRIPTION
## Summary

Fixes three pre-existing test issues flagged by CodeRabbit during the async→sync refactor review (PR #12).

### Fix 1: test_load_documents_force_parameter

The test was creating a `test.json` file (wrong filename — the loader globs for `source.json`). The `load_documents` function never found the file and returned True immediately without exercising the force parameter at all. Assertions were trivially true (`isinstance(success, bool)`).

**Fix**: Now uses the existing fixture at `tests/fixtures/content/documents/` (which has `source.json`, `chunks.json`, and `gran.json`). Test now actually loads a document, verifies `doc_count > 0`, then tests both `force=False` (skip) and `force=True` (reload) paths.

### Fix 2: test_load_documents_parameter_validation

The test had `except Exception: pass` that silently swallowed all errors, making the test permanently green regardless of what the code did.

**Fix**: Removed the try/except. Real failures now propagate and fail the test as intended.

### Fix 3: test_database_functions_interface

The test had `assert result is None` but `check_database_status` always returns `None` (typed `-> None`). The assertion was vacuously true.

**Fix**: Removed the intermediate `result =` assignment and the vacuous assertion. The meaningful behavior — that `check_database_status` completes without raising `DatabaseError` — is now the implicit assertion.

---
*Follows up on CodeRabbit review comments from PR #12.*