### PR TITLE
chore: align ruff config to canonical standard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,9 @@ select = [
     "TID252", # flake8-tidy-imports (relative imports)
     "RUF100", # flag unnecessary noqa comments
 ]
+ignore = [
+    "B9",     # flake8-bugbear opinionated rules (B901-B911)
+]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["S101", "S104"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,4 +134,4 @@ select = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["S101", "S104", "S106"]
+"tests/**" = ["S101", "S104"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,4 +134,4 @@ select = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["S101", "S104", "S106", "S603", "S607", "S608"]
+"tests/**" = ["S101", "S104", "S106"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,3 +135,10 @@ select = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["S101", "S104"]
+
+[tool.ruff.lint.isort]
+case-sensitive = false
+force-single-line = true
+lines-after-imports = 2
+lines-between-types = 1
+order-by-type = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: Text Processing :: General",
 ]
 dependencies = [
-    "cachetools>=6.2.6",
+    "cachetools>=7.1.0",
     "docling>=2.92.0",
     "httpx>=0.28.1",
     "pgvector>=0.4.2",
@@ -37,7 +37,7 @@ dependencies = [
     "psycopg-pool>=3.3.1",
     "pydantic-settings>=2.14.0",
     "pyyaml>=6.0.3",
-    "rich>=14.3.4",
+    "rich>=15.0.0",
     "structlog>=25.5.0",
     "torch>=2.7.1",
     "torchvision>=0.23.0",
@@ -79,12 +79,12 @@ dev = [
     "ipython>=9.13.0",
     "pre-commit>=4.6.0",
     "pyright>=1.1.409",
-    "pytest>=8.4.2",
-    "pytest-cov>=6.3.0",
+    "pytest>=9.0.3",
+    "pytest-cov>=7.1.0",
     "pytest-httpx>=0.36.2",
     "pytest-randomly>=4.1.0",
     "pytest-sugar>=1.1.1",
-    "python-gitlab>=6.5.0",
+    "python-gitlab>=8.3.0",
     "ruff>=0.15.12",
     "tox>=4.53.1",
     "types-cachetools>=6.2.0.20260408",
@@ -115,10 +115,23 @@ venvPath = "."
 venv = ".venv"
 
 [tool.ruff]
-fix = true
+line-length = 120
 
 [tool.ruff.lint]
-select = ["I"]  # Enable import sorting rules
+select = [
+    "E",      # pycodestyle errors
+    "F",      # pyflakes
+    "W",      # pycodestyle warnings
+    "I",      # isort
+    "UP",     # pyupgrade
+    "S",      # bandit (security)
+    "B",      # flake8-bugbear
+    "A",      # flake8-builtins
+    "C4",     # flake8-comprehensions
+    "SIM",    # flake8-simplify
+    "TID252", # flake8-tidy-imports (relative imports)
+    "RUF100", # flag unnecessary noqa comments
+]
 
-[tool.ruff.format]
-preview = true
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S101", "S104", "S106", "S603", "S607", "S608"]

--- a/scripts/rag_demo_client.py
+++ b/scripts/rag_demo_client.py
@@ -29,9 +29,11 @@ Usage:
 import asyncio
 import sys
 
+
 # Try to import docs2db-api
 try:
-    from docs2db_api.rag.engine import RAGConfig, UniversalRAGEngine
+    from docs2db_api.rag.engine import RAGConfig
+    from docs2db_api.rag.engine import UniversalRAGEngine
 except ImportError:
     print("=" * 80)
     print("⚠️  ERROR: docs2db-api is not installed")
@@ -86,7 +88,7 @@ async def test_rag_query(
         enable_question_refinement=enable_refinement,
     )
 
-    print(f"📊 Configuration:")
+    print("📊 Configuration:")
     print(f"   Model: {model}")
     print(f"   Threshold: {threshold}")
     print(f"   Max results: {limit}")
@@ -136,7 +138,7 @@ async def test_rag_query(
             if doc.get("bm25_rank") is not None:
                 print(f"   BM25 Rank: {doc['bm25_rank']:.3f}")
 
-            print(f"   Text preview:")
+            print("   Text preview:")
             text_preview = doc["text"][:200]
             print(f"      {text_preview}...")
 
@@ -209,9 +211,7 @@ async def interactive_rag_test(
 if __name__ == "__main__":
     import argparse
 
-    parser = argparse.ArgumentParser(
-        description="Test RAG functionality using docs2db-api"
-    )
+    parser = argparse.ArgumentParser(description="Test RAG functionality using docs2db-api")
     parser.add_argument(
         "--query",
         "-q",
@@ -243,9 +243,7 @@ if __name__ == "__main__":
         action="store_true",
         help="Disable question refinement",
     )
-    parser.add_argument(
-        "--interactive", "-i", action="store_true", help="Run in interactive mode"
-    )
+    parser.add_argument("--interactive", "-i", action="store_true", help="Run in interactive mode")
 
     args = parser.parse_args()
 
@@ -260,9 +258,5 @@ if __name__ == "__main__":
             )
         )
     else:
-        results = asyncio.run(
-            test_rag_query(
-                args.query, args.limit, args.threshold, args.model, enable_refinement
-            )
-        )
+        results = asyncio.run(test_rag_query(args.query, args.limit, args.threshold, args.model, enable_refinement))
         sys.exit(0 if results else 1)

--- a/src/docs2db/__init__.py
+++ b/src/docs2db/__init__.py
@@ -3,6 +3,7 @@ import os
 
 import structlog
 
+
 # Determine log level from environment
 if os.getenv("DEBUG") == "1":
     log_level = logging.DEBUG

--- a/src/docs2db/audit.py
+++ b/src/docs2db/audit.py
@@ -105,7 +105,6 @@ def perform_audit(
         for source_file in source_files:
             # source_file is .../doc_dir/source.json
             doc_dir = source_file.parent
-            doc_name = doc_dir.name
             # Get full relative path from content directory for better reporting
             doc_rel_path = doc_dir.relative_to(content_path)
 
@@ -151,17 +150,16 @@ def perform_audit(
                             model_config = config
                             break
 
-                    assert model is not None
-                    assert model_config is not None
-                    if chunks_file.exists():
-                        if is_embedding_stale(
-                            embed_file,
-                            chunks_file,
-                            model,
-                            model_config["dimensions"],
-                        ):
-                            messages.append(f"stale embedding   : {doc_rel_path}/{keyword}.json")
-                            has_stale_embedding = True
+                    assert model is not None  # noqa: S101  # RSPEED-3062: replace asserts with guards
+                    assert model_config is not None  # noqa: S101
+                    if chunks_file.exists() and is_embedding_stale(
+                        embed_file,
+                        chunks_file,
+                        model,
+                        model_config["dimensions"],
+                    ):
+                        messages.append(f"stale embedding   : {doc_rel_path}/{keyword}.json")
+                        has_stale_embedding = True
 
             # Advance embed_task once per document, not once per embedding file
             if found_any_embedding:

--- a/src/docs2db/audit.py
+++ b/src/docs2db/audit.py
@@ -1,22 +1,24 @@
 """Audit functionality for finding missing and stale files."""
 
 import json
+
 from pathlib import Path
 
 import structlog
-from rich.progress import (
-    BarColumn,
-    Progress,
-    SpinnerColumn,
-    TaskProgressColumn,
-    TextColumn,
-)
+
+from rich.progress import BarColumn
+from rich.progress import Progress
+from rich.progress import SpinnerColumn
+from rich.progress import TaskProgressColumn
+from rich.progress import TextColumn
 
 from docs2db.chunks import is_chunks_stale
 from docs2db.config import settings
 from docs2db.const import METADATA_SCHEMA_VERSION
-from docs2db.embeddings import EMBEDDING_CONFIGS, is_embedding_stale
+from docs2db.embeddings import EMBEDDING_CONFIGS
+from docs2db.embeddings import is_embedding_stale
 from docs2db.exceptions import ContentError
+
 
 logger = structlog.get_logger(__name__)
 
@@ -96,9 +98,7 @@ def perform_audit(
         metadata_task = progress.add_task("Metadata", total=source_count)
         stale_chunks_task = progress.add_task("Stale chunks", total=source_count)
         stale_embeds_task = progress.add_task("Stale embeds", total=source_count)
-        version_mismatch_task = progress.add_task(
-            "Version mismatches", total=source_count
-        )
+        version_mismatch_task = progress.add_task("Version mismatches", total=source_count)
         orphan_dir_task = progress.add_task("Orphan dirs", total=terminal_count)
         zero_chunks_task = progress.add_task("Zero chunks", total=source_count)
 
@@ -125,9 +125,7 @@ def perform_audit(
                 try:
                     with open(chunks_file) as f:
                         chunks_data = json.load(f)
-                        chunk_count = chunks_data.get("metadata", {}).get(
-                            "chunk_count", 0
-                        )
+                        chunk_count = chunks_data.get("metadata", {}).get("chunk_count", 0)
                         if chunk_count == 0:
                             has_zero_chunks = True
                             progress.advance(zero_chunks_task)
@@ -162,9 +160,7 @@ def perform_audit(
                             model,
                             model_config["dimensions"],
                         ):
-                            messages.append(
-                                f"stale embedding   : {doc_rel_path}/{keyword}.json"
-                            )
+                            messages.append(f"stale embedding   : {doc_rel_path}/{keyword}.json")
                             has_stale_embedding = True
 
             # Advance embed_task once per document, not once per embedding file
@@ -183,11 +179,7 @@ def perform_audit(
             known_files.update(f"{kw}.json" for kw in embedding_keywords)
 
             for file in doc_dir.iterdir():
-                if (
-                    file.is_file()
-                    and file.suffix == ".json"
-                    and file.name not in known_files
-                ):
+                if file.is_file() and file.suffix == ".json" and file.name not in known_files:
                     messages.append(f"unknown file      : {doc_rel_path}/{file.name}")
 
             # Check for meta.json
@@ -208,9 +200,7 @@ def perform_audit(
                     else:
                         progress.advance(metadata_task)
                 except (json.JSONDecodeError, OSError) as e:
-                    messages.append(
-                        f"invalid metadata  : {doc_rel_path}/meta.json ({e})"
-                    )
+                    messages.append(f"invalid metadata  : {doc_rel_path}/meta.json ({e})")
 
         # Check for orphaned directories (terminal directories without source.json)
         for terminal_dir in terminal_dirs:

--- a/src/docs2db/chunks.py
+++ b/src/docs2db/chunks.py
@@ -95,10 +95,7 @@ def is_chunks_stale(chunks_file: Path, source_file: Path) -> bool:
             return True
 
         stored_params = metadata["processing"]["parameters"]
-        if stored_params != CURRENT_METADATA:
-            return True
-
-        return False
+        return stored_params != CURRENT_METADATA
 
     except (json.JSONDecodeError, KeyError, ValueError, FileNotFoundError):
         return True
@@ -281,7 +278,7 @@ class OpenAICompatibleProvider(LLMProvider):
 
 {text}
 
-Summary:"""
+Summary:"""  # noqa: E501
 
         # Log what we're about to send
         word_count = len(prompt.split())
@@ -321,7 +318,7 @@ Summary:"""
             },
             {
                 "role": "user",
-                "content": f"I will give you a document, then ask you to provide context for specific chunks from it.\n\n<document>\n{doc_text}\n</document>",
+                "content": f"I will give you a document, then ask you to provide context for specific chunks from it.\n\n<document>\n{doc_text}\n</document>",  # noqa: E501
             },
             {
                 "role": "assistant",
@@ -380,7 +377,7 @@ class WatsonXProvider(LLMProvider):
             },
             {
                 "role": "user",
-                "content": f"I will give you a document, then ask you to provide context for a specific chunk from it.\n\n<document>\n{self.doc_text}\n</document>",
+                "content": f"I will give you a document, then ask you to provide context for a specific chunk from it.\n\n<document>\n{self.doc_text}\n</document>",  # noqa: E501
             },
             {
                 "role": "assistant",
@@ -406,7 +403,7 @@ class WatsonXProvider(LLMProvider):
 
 {text}
 
-Summary:"""
+Summary:"""  # noqa: E501
 
         messages = [
             {
@@ -582,10 +579,7 @@ class LLMSession:
         doc_chars = len(doc_text)
 
         # Determine model limits
-        if self.context_limit_override:
-            model_limit = self.context_limit_override
-        else:
-            model_limit = MODEL_CONTEXT_LIMITS.get(self.model, 32768)
+        model_limit = self.context_limit_override or MODEL_CONTEXT_LIMITS.get(self.model, 32768)
         usable_limit = int(model_limit * CONTEXT_SAFETY_MARGIN)
 
         logger.debug(
@@ -614,7 +608,7 @@ class LLMSession:
 {chunk_text}
 </chunk>
 
-Please give a short succinct context to situate this chunk within the overall document for the purposes of improving search retrieval of the chunk. Answer only with the succinct context and nothing else."""
+Please give a short succinct context to situate this chunk within the overall document for the purposes of improving search retrieval of the chunk. Answer only with the succinct context and nothing else."""  # noqa: E501
 
         return self.provider.get_chunk_context(chunk_prompt)
 
@@ -665,7 +659,7 @@ def generate_chunks_for_document(
 
     # Reuse LLM session if context generation is enabled
     if not skip_context:
-        assert llm_session is not None
+        assert llm_session is not None  # noqa: S101
         doc_text = dl_doc.export_to_markdown()
         llm_session.set_document(doc_text)
 
@@ -891,9 +885,9 @@ def generate_chunks_batch(
     finally:
         # Clean up the reusable session
         if reusable_llm_session:
-            try:
+            try:  # noqa: SIM105
                 reusable_llm_session.close()
-            except Exception:
+            except Exception:  # noqa: S110
                 pass  # Don't mask exceptions from try block
 
     # Report worker memory footprint.
@@ -936,7 +930,8 @@ def generate_chunks(
         provider: LLM provider ("openai" or "watsonx"); inferred from URLs or defaults to settings.llm_provider.
         openai_url: OpenAI-compatible API URL (defaults to settings.llm_openai_url).
         watsonx_url: WatsonX API URL (defaults to settings.llm_watsonx_url).
-        context_limit_override: Override model context limit in tokens (defaults to settings.llm_context_limit_override).
+        context_limit_override: Override model context limit in tokens
+            (defaults to settings.llm_context_limit_override).
 
     Returns:
         bool: True if successful, False if any errors occurred.

--- a/src/docs2db/chunks.py
+++ b/src/docs2db/chunks.py
@@ -4,8 +4,11 @@ import json
 import logging
 import os
 import time
-from abc import ABC, abstractmethod
-from datetime import datetime, timezone
+
+from abc import ABC
+from abc import abstractmethod
+from datetime import datetime
+from datetime import UTC
 from functools import cache
 from pathlib import Path
 from typing import Any
@@ -13,6 +16,7 @@ from typing import Any
 import httpx
 import psutil
 import structlog
+
 from docling_core.transforms.chunker.hybrid_chunker import HybridChunker
 from docling_core.transforms.chunker.tokenizer.huggingface import HuggingFaceTokenizer
 from docling_core.types.doc.document import DoclingDocument
@@ -20,13 +24,14 @@ from transformers import AutoTokenizer
 from transformers.utils import logging as transformers_logging
 
 from docs2db.config import settings
-from docs2db.const import (
-    CHUNKING_CONFIG,
-    CHUNKING_SCHEMA_VERSION,
-    DATABASE_SCHEMA_VERSION,
-)
-from docs2db.multiproc import BatchProcessor, setup_worker_logging
-from docs2db.utils import ensure_model_available, hash_file
+from docs2db.const import CHUNKING_CONFIG
+from docs2db.const import CHUNKING_SCHEMA_VERSION
+from docs2db.const import DATABASE_SCHEMA_VERSION
+from docs2db.multiproc import BatchProcessor
+from docs2db.multiproc import setup_worker_logging
+from docs2db.utils import ensure_model_available
+from docs2db.utils import hash_file
+
 
 logger = structlog.get_logger(__name__)
 
@@ -342,13 +347,9 @@ class WatsonXProvider(LLMProvider):
             model: Model identifier
         """
         try:
-            from ibm_watsonx_ai import (  # type: ignore[import-untyped]
-                APIClient,
-                Credentials,
-            )
-            from ibm_watsonx_ai.foundation_models import (  # type: ignore[import-untyped]
-                ModelInference,
-            )
+            from ibm_watsonx_ai import APIClient  # type: ignore[import-untyped]
+            from ibm_watsonx_ai import Credentials  # type: ignore[import-untyped]
+            from ibm_watsonx_ai.foundation_models import ModelInference  # type: ignore[import-untyped]
         except ImportError as e:
             raise ImportError(
                 "IBM WatsonX AI SDK is required for WatsonX provider. "
@@ -446,9 +447,7 @@ Summary:"""
         pass
 
 
-def map_reduce_summarize(
-    provider: LLMProvider, text: str, max_tokens: int, model: str
-) -> str:
+def map_reduce_summarize(provider: LLMProvider, text: str, max_tokens: int, model: str) -> str:
     """Summarize large text using map-reduce approach.
 
     Args:
@@ -460,10 +459,7 @@ def map_reduce_summarize(
     Returns:
         str: Summarized text that fits within context limit
     """
-    logger.info(
-        f"Document too large for model context window. "
-        f"Starting map-reduce summarization (model: {model})"
-    )
+    logger.info(f"Document too large for model context window. Starting map-reduce summarization (model: {model})")
 
     # Reserve tokens for prompt overhead and response
     # Summarization prompt adds ~100 tokens, response uses 500 tokens
@@ -471,25 +467,18 @@ def map_reduce_summarize(
     chunk_size = max_tokens - PROMPT_OVERHEAD
 
     if chunk_size <= 0:
-        raise ValueError(
-            f"max_tokens ({max_tokens}) too small to allow for prompt overhead"
-        )
+        raise ValueError(f"max_tokens ({max_tokens}) too small to allow for prompt overhead")
 
     # Split text into chunks, accounting for prompt overhead
     chunks = split_text_into_chunks(text, chunk_size)
-    logger.info(
-        f"Split document into {len(chunks)} chunks for summarization (chunk_size: {chunk_size} tokens)"
-    )
+    logger.info(f"Split document into {len(chunks)} chunks for summarization (chunk_size: {chunk_size} tokens)")
 
     # Map: Summarize each chunk
     summaries = []
     for i, chunk in enumerate(chunks, 1):
         chunk_words = len(chunk.split())
         chunk_tokens = estimate_tokens(chunk)
-        logger.info(
-            f"Summarizing chunk {i}/{len(chunks)}: "
-            f"{chunk_words} words, {chunk_tokens} estimated tokens"
-        )
+        logger.info(f"Summarizing chunk {i}/{len(chunks)}: {chunk_words} words, {chunk_tokens} estimated tokens")
         summary = provider.summarize_text(chunk)
         summaries.append(summary)
 
@@ -549,18 +538,13 @@ class LLMSession:
         if provider == "watsonx":
             # Use WatsonX provider
             if not self.watsonx_url:
-                raise ValueError(
-                    "provider is 'watsonx' but watsonx_url is None. "
-                    "WatsonX API URL is required."
-                )
+                raise ValueError("provider is 'watsonx' but watsonx_url is None. WatsonX API URL is required.")
 
             api_key = settings.watsonx_api_key
             project_id = settings.watsonx_project_id
 
             if not api_key or not project_id:
-                raise ValueError(
-                    "WATSONX_API_KEY and WATSONX_PROJECT_ID must be set (via env vars or .env file)"
-                )
+                raise ValueError("WATSONX_API_KEY and WATSONX_PROJECT_ID must be set (via env vars or .env file)")
 
             self.provider = WatsonXProvider(
                 api_key=api_key,
@@ -581,10 +565,7 @@ class LLMSession:
                 model=self.model,
             )
         else:
-            raise ValueError(
-                f"Unknown provider: '{provider}'. "
-                "Valid options are 'openai' or 'watsonx'."
-            )
+            raise ValueError(f"Unknown provider: '{provider}'. Valid options are 'openai' or 'watsonx'.")
 
     def set_document(self, doc_text: str):
         """Set the document that will be used for context generation.
@@ -615,16 +596,11 @@ class LLMSession:
         # Check if summarization is needed
         if doc_tokens > usable_limit:
             logger.info(
-                f"Document exceeds context limit ({doc_tokens} > {usable_limit}). "
-                f"Using map-reduce summarization."
+                f"Document exceeds context limit ({doc_tokens} > {usable_limit}). Using map-reduce summarization."
             )
-            doc_text = map_reduce_summarize(
-                self.provider, doc_text, usable_limit, self.model
-            )
+            doc_text = map_reduce_summarize(self.provider, doc_text, usable_limit, self.model)
             final_tokens = estimate_tokens(doc_text)
-            logger.info(
-                f"Summarization complete. Reduced from {doc_tokens} to {final_tokens} tokens"
-            )
+            logger.info(f"Summarization complete. Reduced from {doc_tokens} to {final_tokens} tokens")
             self._was_summarized = True
 
         # Update provider with (potentially summarized) document
@@ -681,9 +657,7 @@ def generate_chunks_for_document(
     if not force and not is_chunks_stale(chunks_file, source_file):
         return chunks_file
 
-    dl_doc = DoclingDocument.model_validate_json(
-        json_data=source_file.read_text().encode("utf-8")
-    )
+    dl_doc = DoclingDocument.model_validate_json(json_data=source_file.read_text().encode("utf-8"))
 
     # Create chunker and chunk document
     chunker = HybridChunker(tokenizer=get_tokenizer(), merge_peers=True)
@@ -745,11 +719,7 @@ def generate_chunks_for_document(
             enrichment_metadata["endpoint"] = "http://localhost:11434"
 
         # Only include document_summarized if it actually happened
-        if (
-            llm_session
-            and hasattr(llm_session, "_was_summarized")
-            and llm_session._was_summarized
-        ):
+        if llm_session and hasattr(llm_session, "_was_summarized") and llm_session._was_summarized:
             enrichment_metadata["document_summarized"] = True
 
         # Only include context_limit_override if it was set
@@ -765,7 +735,7 @@ def generate_chunks_for_document(
             "database_schema_version": DATABASE_SCHEMA_VERSION,
             "chunking_schema_version": CHUNKING_SCHEMA_VERSION,
             "processing": processing_metadata,
-            "created_at": datetime.now(timezone.utc).isoformat(),
+            "created_at": datetime.now(UTC).isoformat(),
             "chunk_count": len(chunks_data),
         },
         "chunks": chunks_data,
@@ -896,9 +866,7 @@ def generate_chunks_batch(
                     "worker_logs": log_collector.logs,
                 }
         else:
-            logger.debug(
-                "All files in batch already processed, skipping LLM session creation"
-            )
+            logger.debug("All files in batch already processed, skipping LLM session creation")
 
     try:
         for file in source_files:

--- a/src/docs2db/database.py
+++ b/src/docs2db/database.py
@@ -896,9 +896,7 @@ class DatabaseManager:
                             )
 
                         # Prepare chunks data for this document
-                        for chunk_idx, (chunk, embedding_vector) in enumerate(
-                            zip(chunks, embedding_vectors, strict=False)
-                        ):
+                        for chunk_idx, (chunk, embedding_vector) in enumerate(zip(chunks, embedding_vectors)):
                             chunk_data = (
                                 document_id,
                                 chunk_idx,
@@ -1259,7 +1257,7 @@ def check_database_status(
             metadata_row = metadata_result.fetchone()
             if metadata_row and metadata_result.description:
                 columns = [desc[0] for desc in metadata_result.description]
-                metadata = dict(zip(columns, metadata_row, strict=False))
+                metadata = dict(zip(columns, metadata_row))
 
                 logger.info(
                     "\nSchema Metadata:\n"
@@ -1301,7 +1299,7 @@ def check_database_status(
             for row in changes_result:
                 if changes_result.description:
                     columns = [desc[0] for desc in changes_result.description]
-                    change_data = dict(zip(columns, row, strict=False))
+                    change_data = dict(zip(columns, row))
                     changes.append(change_data)
 
             if changes:

--- a/src/docs2db/database.py
+++ b/src/docs2db/database.py
@@ -230,7 +230,7 @@ class DatabaseManager:
 
         if updates:
             updates.append("last_modified_at = NOW()")
-            sql = f"UPDATE schema_metadata SET {', '.join(updates)} WHERE id = 1"
+            sql = f"UPDATE schema_metadata SET {', '.join(updates)} WHERE id = 1"  # noqa: S608
             conn.execute(sql, params)
 
     def format_schema_change_display(self, change_data: dict) -> str:
@@ -687,7 +687,7 @@ class DatabaseManager:
                     updated_fields.append("refinement_questions_count")
 
                 if updates:
-                    update_sql = f"UPDATE rag_settings SET {', '.join(updates)} WHERE id = 1"
+                    update_sql = f"UPDATE rag_settings SET {', '.join(updates)} WHERE id = 1"  # noqa: S608
                     conn.execute(update_sql, values)
                     logger.info(f"RAG settings updated: {', '.join(updated_fields)}")
                 else:
@@ -771,7 +771,7 @@ class DatabaseManager:
         for (
             source_file,
             chunks_file,
-            model_name,
+            _model_name,
             embedding_data,
             embedding_file,
         ) in files_data:
@@ -785,7 +785,8 @@ class DatabaseManager:
 
                 if len(chunks) != len(embedding_vectors):
                     logger.error(
-                        f"Chunks count ({len(chunks)}) != embeddings count ({len(embedding_vectors)}) for {source_file.name}"
+                        f"Chunks count ({len(chunks)}) != embeddings count "
+                        f"({len(embedding_vectors)}) for {source_file.name}"
                     )
                     errors += 1
                     continue
@@ -867,7 +868,8 @@ class DatabaseManager:
                         # Insert/update document
                         doc_result = conn.execute(
                             """
-                            INSERT INTO documents (path, filename, content_type, file_size, last_modified, chunks_file_path)
+                            INSERT INTO documents
+                                (path, filename, content_type, file_size, last_modified, chunks_file_path)
                             VALUES (%s, %s, %s, %s, %s, %s)
                             ON CONFLICT (path) DO UPDATE SET
                                 filename = EXCLUDED.filename,
@@ -933,7 +935,8 @@ class DatabaseManager:
                         conn.execute(SQL("SAVEPOINT {}").format(Identifier(f"sp_chunk_{idx}")))
                         chunk_result = conn.execute(
                             """
-                            INSERT INTO chunks (document_id, chunk_index, text, contextual_text, metadata, text_search_vector)
+                            INSERT INTO chunks
+                                (document_id, chunk_index, text, contextual_text, metadata, text_search_vector)
                             VALUES (%s, %s, %s, %s, %s, to_tsvector('english', %s))
                             ON CONFLICT (document_id, chunk_index) DO UPDATE SET
                                 text = EXCLUDED.text,
@@ -1264,9 +1267,10 @@ def check_database_status(
                     f"  Title          : {metadata['title'] or '(not set)'}\n"
                     f"  Description    : {metadata['description'] or '(not set)'}\n"
                     f"  Models         : {metadata['embedding_models_count']}\n"
-                    f"  Last modified  : {metadata['last_modified_at'].strftime('%Y-%m-%d %H:%M') if metadata['last_modified_at'] else 'Unknown'}"
+                    f"  Last modified  : "
+                    f"{metadata['last_modified_at'].strftime('%Y-%m-%d %H:%M') if metadata['last_modified_at'] else 'Unknown'}"  # noqa: E501
                 )
-        except Exception:
+        except Exception:  # noqa: S110
             # Schema metadata table doesn't exist yet
             pass
 
@@ -1304,7 +1308,7 @@ def check_database_status(
                 logger.info("\nRecent Changes (last 5):")
                 for change_data in changes:
                     logger.info(db_manager.format_schema_change_display(change_data))
-        except Exception:
+        except Exception:  # noqa: S110
             # Schema changes table doesn't exist yet
             pass
 
@@ -1326,7 +1330,12 @@ def check_database_status(
                 path, created_at, updated_at = row
                 # Strip /source.json suffix for cleaner display
                 display_path = path.removesuffix("/source.json")
-                file_str += f"  {display_path}\n    created: {created_at.strftime('%Y-%m-%d %H:%M')}\n    updated: {updated_at.strftime('%Y-%m-%d %H:%M') if updated_at else 'Never'}\n"
+                updated_str = updated_at.strftime("%Y-%m-%d %H:%M") if updated_at else "Never"
+                file_str += (
+                    f"  {display_path}\n"
+                    f"    created: {created_at.strftime('%Y-%m-%d %H:%M')}\n"
+                    f"    updated: {updated_str}\n"
+                )
             logger.info(f"\nRecent document activity (last 5)\n{file_str}")
 
         # Database size information
@@ -1864,7 +1873,7 @@ def dump_database(
         logger.info("Creating database dump...")
 
         # Run pg_dump
-        subprocess.run(
+        subprocess.run(  # noqa: S603
             cmd,
             env=env,
             capture_output=not verbose,
@@ -1954,7 +1963,7 @@ def restore_database(
         logger.info("Restoring database from dump...")
 
         # Run psql
-        subprocess.run(
+        subprocess.run(  # noqa: S603
             cmd,
             env=env,
             capture_output=not verbose,
@@ -2079,7 +2088,7 @@ def configure_rag_settings(
         try:
             return type_func(value), False
         except ValueError:
-            raise ConfigurationError(f"{name}: must be a number or 'None', got '{value}'")
+            raise ConfigurationError(f"{name}: must be a number or 'None', got '{value}'") from None
 
     # Parse refinement_prompt (string)
     if refinement_prompt is not None:

--- a/src/docs2db/database.py
+++ b/src/docs2db/database.py
@@ -5,26 +5,35 @@ import logging
 import os
 import subprocess
 import time
-from datetime import datetime, timezone
+
+from datetime import datetime
+from datetime import UTC
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import psutil
 import psycopg
 import structlog
 import yaml
-from psycopg.sql import SQL, Identifier
+
+from psycopg.sql import Identifier
+from psycopg.sql import SQL
 
 from docs2db.config import settings
 from docs2db.const import DATABASE_SCHEMA_VERSION
-from docs2db.embeddings import EMBEDDING_CONFIGS, create_embedding_filename
-from docs2db.exceptions import ConfigurationError, ContentError, DatabaseError
-from docs2db.multiproc import BatchProcessor, setup_worker_logging
+from docs2db.embeddings import create_embedding_filename
+from docs2db.embeddings import EMBEDDING_CONFIGS
+from docs2db.exceptions import ConfigurationError
+from docs2db.exceptions import ContentError
+from docs2db.exceptions import DatabaseError
+from docs2db.multiproc import BatchProcessor
+from docs2db.multiproc import setup_worker_logging
+
 
 logger = structlog.get_logger()
 
 
-def get_db_config() -> Dict[str, str]:
+def get_db_config() -> dict[str, str]:
     """Get database connection parameters from multiple sources.
 
     Configuration precedence (highest to lowest):
@@ -41,13 +50,15 @@ def get_db_config() -> Dict[str, str]:
     """
     # Check for conflicting configuration sources
     has_database_url = bool(os.getenv("DATABASE_URL"))
-    has_postgres_vars = any([
-        os.getenv("POSTGRES_HOST"),
-        os.getenv("POSTGRES_PORT"),
-        os.getenv("POSTGRES_DB"),
-        os.getenv("POSTGRES_USER"),
-        os.getenv("POSTGRES_PASSWORD"),
-    ])
+    has_postgres_vars = any(
+        [
+            os.getenv("POSTGRES_HOST"),
+            os.getenv("POSTGRES_PORT"),
+            os.getenv("POSTGRES_DB"),
+            os.getenv("POSTGRES_USER"),
+            os.getenv("POSTGRES_PASSWORD"),
+        ]
+    )
 
     if has_database_url and has_postgres_vars:
         raise ConfigurationError(
@@ -68,7 +79,7 @@ def get_db_config() -> Dict[str, str]:
     compose_file = Path.cwd() / "postgres-compose.yml"
     if compose_file.exists():
         try:
-            with open(compose_file, "r") as f:
+            with open(compose_file) as f:
                 compose_data = yaml.safe_load(f)
 
             db_service = compose_data.get("services", {}).get("db", {})
@@ -124,9 +135,7 @@ def get_db_config() -> Dict[str, str]:
                     else:
                         config["host"] = host_port
                 else:
-                    raise ConfigurationError(
-                        f"Invalid DATABASE_URL format (missing @): {database_url}"
-                    )
+                    raise ConfigurationError(f"Invalid DATABASE_URL format (missing @): {database_url}")
             else:
                 raise ConfigurationError(
                     f"Invalid DATABASE_URL scheme. Expected postgresql:// or postgres://, "
@@ -136,8 +145,7 @@ def get_db_config() -> Dict[str, str]:
             raise
         except Exception as e:
             raise ConfigurationError(
-                f"Failed to parse DATABASE_URL: {e}. "
-                f"Expected format: postgresql://user:password@host:port/database"
+                f"Failed to parse DATABASE_URL: {e}. Expected format: postgresql://user:password@host:port/database"
             ) from e
 
     # Individual environment variables override everything (highest precedence)
@@ -185,8 +193,8 @@ class DatabaseManager:
     def insert_schema_metadata(
         self,
         conn,
-        title: Optional[str] = None,
-        description: Optional[str] = None,
+        title: str | None = None,
+        description: str | None = None,
     ) -> None:
         """Insert initial schema metadata record."""
         conn.execute(
@@ -202,9 +210,9 @@ class DatabaseManager:
     def update_schema_metadata(
         self,
         conn,
-        title: Optional[str] = None,
-        description: Optional[str] = None,
-        embedding_models_count: Optional[int] = None,
+        title: str | None = None,
+        description: str | None = None,
+        embedding_models_count: int | None = None,
     ) -> None:
         """Update schema metadata record."""
         updates = []
@@ -236,11 +244,7 @@ class DatabaseManager:
         lines.append(f"\nUpdate #{change_data['id']}:")
 
         # Timestamp (always show)
-        timestamp = (
-            change_data["changed_at"].strftime("%Y-%m-%d %H:%M")
-            if change_data["changed_at"]
-            else "Unknown"
-        )
+        timestamp = change_data["changed_at"].strftime("%Y-%m-%d %H:%M") if change_data["changed_at"] else "Unknown"
         lines.append(f"  Timestamp      : {timestamp}")
 
         # User (only if set)
@@ -289,8 +293,8 @@ class DatabaseManager:
         conn,
         name: str,
         dimensions: int,
-        provider: Optional[str] = None,
-        description: Optional[str] = None,
+        provider: str | None = None,
+        description: str | None = None,
     ) -> int:
         """Insert a new model and return its ID.
 
@@ -318,13 +322,13 @@ class DatabaseManager:
 
         return row[0]
 
-    def get_model(self, conn, name: str) -> Optional[int]:
+    def get_model(self, conn, name: str) -> int | None:
         """Get model ID by name."""
         result = conn.execute("SELECT id FROM models WHERE name = %s", [name])
         row = result.fetchone()
         return row[0] if row else None
 
-    def get_model_info(self, conn, model: int) -> Optional[dict]:
+    def get_model_info(self, conn, model: int) -> dict | None:
         """Get model information by ID."""
         result = conn.execute(
             "SELECT id, name, dimensions, provider, description, created_at FROM models WHERE id = %s",
@@ -352,7 +356,7 @@ class DatabaseManager:
         chunks_deleted: int = 0,
         embeddings_added: int = 0,
         embeddings_deleted: int = 0,
-        embedding_models_added: Optional[List[str]] = None,
+        embedding_models_added: list[str] | None = None,
         notes: str = "",
     ) -> None:
         """Insert a schema change record."""
@@ -549,22 +553,20 @@ class DatabaseManager:
                 self.insert_schema_metadata(conn)
 
                 # Insert initial change record (creation event)
-                self.insert_schema_change(
-                    conn, changed_by_user="", notes="Database initialized"
-                )
+                self.insert_schema_change(conn, changed_by_user="", notes="Database initialized")
 
                 conn.commit()
                 logger.info("Database schema initialized successfully")
 
     def update_rag_settings(
         self,
-        refinement_prompt: Optional[str] = None,
-        enable_refinement: Optional[bool] = None,
-        enable_reranking: Optional[bool] = None,
-        similarity_threshold: Optional[float] = None,
-        max_chunks: Optional[int] = None,
-        max_tokens_in_context: Optional[int] = None,
-        refinement_questions_count: Optional[int] = None,
+        refinement_prompt: str | None = None,
+        enable_refinement: bool | None = None,
+        enable_reranking: bool | None = None,
+        similarity_threshold: float | None = None,
+        max_chunks: int | None = None,
+        max_tokens_in_context: int | None = None,
+        refinement_questions_count: int | None = None,
         _clear_refinement_prompt: bool = False,
         _clear_enable_refinement: bool = False,
         _clear_enable_reranking: bool = False,
@@ -685,9 +687,7 @@ class DatabaseManager:
                     updated_fields.append("refinement_questions_count")
 
                 if updates:
-                    update_sql = (
-                        f"UPDATE rag_settings SET {', '.join(updates)} WHERE id = 1"
-                    )
+                    update_sql = f"UPDATE rag_settings SET {', '.join(updates)} WHERE id = 1"
                     conn.execute(update_sql, values)
                     logger.info(f"RAG settings updated: {', '.join(updated_fields)}")
                 else:
@@ -695,7 +695,7 @@ class DatabaseManager:
 
             conn.commit()
 
-    def get_rag_settings(self) -> Optional[Dict[str, Any]]:
+    def get_rag_settings(self) -> dict[str, Any] | None:
         """Get RAG settings from the database.
 
         Returns:
@@ -731,12 +731,12 @@ class DatabaseManager:
 
     def load_document_batch(
         self,
-        files_data: List[
-            Tuple[Path, Path, str, Dict[str, Any], Path]
+        files_data: list[
+            tuple[Path, Path, str, dict[str, Any], Path]
         ],  # (source_file, chunks_file, model, embedding_data, embedding_file)
         content_dir: Path,
         force: bool = False,
-    ) -> Tuple[int, int]:
+    ) -> tuple[int, int]:
         """Load a batch of documents, chunks, and embeddings using bulk operations."""
 
         processed = 0
@@ -777,7 +777,7 @@ class DatabaseManager:
         ) in files_data:
             try:
                 # Load chunks data
-                with open(chunks_file, "r", encoding="utf-8") as f:
+                with open(chunks_file, encoding="utf-8") as f:
                     chunks_json = json.load(f)
 
                 chunks = chunks_json.get("chunks", [])
@@ -800,14 +800,16 @@ class DatabaseManager:
                     self._convert_timestamp(stats.st_mtime),
                     str(chunks_file),
                 )
-                documents_data.append((
-                    source_file,
-                    doc_data,
-                    chunks,
-                    embedding_vectors,
-                    model_id,
-                    embedding_file,
-                ))
+                documents_data.append(
+                    (
+                        source_file,
+                        doc_data,
+                        chunks,
+                        embedding_vectors,
+                        model_id,
+                        embedding_file,
+                    )
+                )
 
             except Exception as e:
                 logger.error(f"Failed to prepare {source_file.name}: {e}")
@@ -830,9 +832,7 @@ class DatabaseManager:
                     embedding_file,
                 ) in enumerate(documents_data):
                     try:
-                        conn.execute(
-                            SQL("SAVEPOINT {}").format(Identifier(f"sp_doc_{idx}"))
-                        )
+                        conn.execute(SQL("SAVEPOINT {}").format(Identifier(f"sp_doc_{idx}")))
                         # Check if we should skip (not force and current embeddings exist)
                         if not force:
                             # Get existing embeddings creation time
@@ -857,7 +857,7 @@ class DatabaseManager:
                                 # Get embedding file modification time
                                 if embedding_file and embedding_file.exists():
                                     embedding_file_mtime = datetime.fromtimestamp(
-                                        embedding_file.stat().st_mtime, tz=timezone.utc
+                                        embedding_file.stat().st_mtime, tz=UTC
                                     )
 
                                     # Skip only if database embeddings are newer than the embedding file
@@ -881,9 +881,7 @@ class DatabaseManager:
                         )
                         doc_row = doc_result.fetchone()
                         if doc_row is None:
-                            raise DatabaseError(
-                                f"Failed to insert/update document: {source_file}"
-                            )
+                            raise DatabaseError(f"Failed to insert/update document: {source_file}")
 
                         document_id = doc_row[0]
                         doc_path_to_id[str(source_file)] = document_id
@@ -906,29 +904,21 @@ class DatabaseManager:
                                 chunk["contextual_text"],
                                 json.dumps(chunk.get("metadata", {})),
                             )
-                            chunks_data.append((
-                                source_file,
-                                chunk_data,
-                                embedding_vector,
-                                model_id,
-                            ))
-
-                        conn.execute(
-                            SQL("RELEASE SAVEPOINT {}").format(
-                                Identifier(f"sp_doc_{idx}")
+                            chunks_data.append(
+                                (
+                                    source_file,
+                                    chunk_data,
+                                    embedding_vector,
+                                    model_id,
+                                )
                             )
-                        )
+
+                        conn.execute(SQL("RELEASE SAVEPOINT {}").format(Identifier(f"sp_doc_{idx}")))
                         processed += 1
 
                     except Exception as e:
-                        conn.execute(
-                            SQL("ROLLBACK TO SAVEPOINT {}").format(
-                                Identifier(f"sp_doc_{idx}")
-                            )
-                        )
-                        logger.error(
-                            f"Failed to process document {source_file.name}: {e}"
-                        )
+                        conn.execute(SQL("ROLLBACK TO SAVEPOINT {}").format(Identifier(f"sp_doc_{idx}")))
+                        logger.error(f"Failed to process document {source_file.name}: {e}")
                         errors += 1
                         continue
 
@@ -940,9 +930,7 @@ class DatabaseManager:
                     _,
                 ) in enumerate(chunks_data):
                     try:
-                        conn.execute(
-                            SQL("SAVEPOINT {}").format(Identifier(f"sp_chunk_{idx}"))
-                        )
+                        conn.execute(SQL("SAVEPOINT {}").format(Identifier(f"sp_chunk_{idx}")))
                         chunk_result = conn.execute(
                             """
                             INSERT INTO chunks (document_id, chunk_index, text, contextual_text, metadata, text_search_vector)
@@ -954,14 +942,11 @@ class DatabaseManager:
                                 text_search_vector = to_tsvector('english', EXCLUDED.contextual_text)
                             RETURNING id
                             """,
-                            chunk_data
-                            + (chunk_data[3],),  # Add contextual_text for tsvector
+                            chunk_data + (chunk_data[3],),  # Add contextual_text for tsvector
                         )
                         chunk_row = chunk_result.fetchone()
                         if chunk_row is None:
-                            raise DatabaseError(
-                                f"Failed to insert chunk for {source_file}"
-                            )
+                            raise DatabaseError(f"Failed to insert chunk for {source_file}")
 
                         chunk_id = chunk_row[0]
 
@@ -972,27 +957,17 @@ class DatabaseManager:
                             embedding_vector,
                         )
                         embeddings_data.append(embedding_data_tuple)
-                        conn.execute(
-                            SQL("RELEASE SAVEPOINT {}").format(
-                                Identifier(f"sp_chunk_{idx}")
-                            )
-                        )
+                        conn.execute(SQL("RELEASE SAVEPOINT {}").format(Identifier(f"sp_chunk_{idx}")))
 
                     except Exception as e:
-                        conn.execute(
-                            SQL("ROLLBACK TO SAVEPOINT {}").format(
-                                Identifier(f"sp_chunk_{idx}")
-                            )
-                        )
+                        conn.execute(SQL("ROLLBACK TO SAVEPOINT {}").format(Identifier(f"sp_chunk_{idx}")))
                         logger.error(f"Failed to insert chunk for {source_file}: {e}")
                         errors += 1
 
                 # Bulk insert embeddings
                 for idx, embedding_tuple in enumerate(embeddings_data):
                     try:
-                        conn.execute(
-                            SQL("SAVEPOINT {}").format(Identifier(f"sp_emb_{idx}"))
-                        )
+                        conn.execute(SQL("SAVEPOINT {}").format(Identifier(f"sp_emb_{idx}")))
                         conn.execute(
                             """
                             INSERT INTO embeddings (chunk_id, model, embedding)
@@ -1003,17 +978,9 @@ class DatabaseManager:
                             """,
                             embedding_tuple,
                         )
-                        conn.execute(
-                            SQL("RELEASE SAVEPOINT {}").format(
-                                Identifier(f"sp_emb_{idx}")
-                            )
-                        )
+                        conn.execute(SQL("RELEASE SAVEPOINT {}").format(Identifier(f"sp_emb_{idx}")))
                     except Exception as e:
-                        conn.execute(
-                            SQL("ROLLBACK TO SAVEPOINT {}").format(
-                                Identifier(f"sp_emb_{idx}")
-                            )
-                        )
+                        conn.execute(SQL("ROLLBACK TO SAVEPOINT {}").format(Identifier(f"sp_emb_{idx}")))
                         logger.error(f"Failed to insert embedding: {e}")
                         errors += 1
 
@@ -1042,9 +1009,9 @@ class DatabaseManager:
 
     def _convert_timestamp(self, unix_timestamp: float):
         """Convert Unix timestamp to datetime object for PostgreSQL."""
-        return datetime.fromtimestamp(unix_timestamp, tz=timezone.utc)
+        return datetime.fromtimestamp(unix_timestamp, tz=UTC)
 
-    def get_stats(self) -> Dict[str, Any]:
+    def get_stats(self) -> dict[str, Any]:
         """Get database statistics."""
         with self.get_direct_connection() as conn:
             # Document stats
@@ -1138,11 +1105,11 @@ class DatabaseManager:
 
 
 def check_database_status(
-    host: Optional[str] = None,
-    port: Optional[int] = None,
-    db: Optional[str] = None,
-    user: Optional[str] = None,
-    password: Optional[str] = None,
+    host: str | None = None,
+    port: int | None = None,
+    db: str | None = None,
+    user: str | None = None,
+    password: str | None = None,
 ) -> None:
     """Check database connectivity and display statistics."""
     db_defaults = get_db_config()
@@ -1153,11 +1120,7 @@ def check_database_status(
     password = password if password is not None else db_defaults["password"]
 
     logger.info(
-        "\nCheck database status:\n"
-        f"  Host    : {host}\n"
-        f"  Port    : {port}\n"
-        f"  Database: {db}\n"
-        f"  user    : {user}"
+        f"\nCheck database status:\n  Host    : {host}\n  Port    : {port}\n  Database: {db}\n  user    : {user}"
     )
 
     # Suppress psycopg connection warnings for cleaner error messages
@@ -1197,9 +1160,7 @@ def check_database_status(
             or "could not receive data" in error_msg
             or "couldn't get a connection" in error_msg
         ):
-            logger.error(
-                "Database is not running. Start database with 'docs2db db-start'"
-            )
+            logger.error("Database is not running. Start database with 'docs2db db-start'")
         elif (
             "authentication failed" in error_msg
             or "no password supplied" in error_msg
@@ -1228,9 +1189,7 @@ def check_database_status(
 
     # Check for pgvector extension
     with db_manager.get_direct_connection() as conn:
-        ext_result = conn.execute(
-            "SELECT extname, extversion FROM pg_extension WHERE extname = 'vector'"
-        )
+        ext_result = conn.execute("SELECT extname, extversion FROM pg_extension WHERE extname = 'vector'")
         ext_row = ext_result.fetchone()
         if ext_row:
             _ext_name, ext_version = ext_row
@@ -1265,17 +1224,13 @@ def check_database_status(
             )
             raise DatabaseError("Partial schema found")
         else:
-            logger.error(
-                "No docs2db tables found. Run 'uv run docs2db load' to initialize"
-            )
+            logger.error("No docs2db tables found. Run 'uv run docs2db load' to initialize")
             raise DatabaseError("No docs2db tables found")
 
     # Get database statistics
     stats = db_manager.get_stats()
 
-    total_embeddings = sum(
-        model_info["count"] for model_info in stats["embedding_models"].values()
-    )
+    total_embeddings = sum(model_info["count"] for model_info in stats["embedding_models"].values())
 
     logger.info(
         "\nDatabase statistics summary:\n"
@@ -1301,7 +1256,7 @@ def check_database_status(
             metadata_row = metadata_result.fetchone()
             if metadata_row and metadata_result.description:
                 columns = [desc[0] for desc in metadata_result.description]
-                metadata = dict(zip(columns, metadata_row))
+                metadata = dict(zip(columns, metadata_row, strict=False))
 
                 logger.info(
                     "\nSchema Metadata:\n"
@@ -1342,7 +1297,7 @@ def check_database_status(
             for row in changes_result:
                 if changes_result.description:
                     columns = [desc[0] for desc in changes_result.description]
-                    change_data = dict(zip(columns, row))
+                    change_data = dict(zip(columns, row, strict=False))
                     changes.append(change_data)
 
             if changes:
@@ -1376,9 +1331,7 @@ def check_database_status(
 
         # Database size information
         with db_manager.get_direct_connection() as conn:
-            size_result = conn.execute(
-                "SELECT pg_size_pretty(pg_database_size(%s)) as db_size", (db,)
-            )
+            size_result = conn.execute("SELECT pg_size_pretty(pg_database_size(%s)) as db_size", (db,))
             size_row = size_result.fetchone()
             if size_row:
                 db_size = size_row[0]
@@ -1390,29 +1343,17 @@ def check_database_status(
         # Format non-None settings for display
         settings_lines = []
         if rag_settings["enable_refinement"] is not None:
-            settings_lines.append(
-                f"  enable_refinement         : {rag_settings['enable_refinement']}"
-            )
+            settings_lines.append(f"  enable_refinement         : {rag_settings['enable_refinement']}")
         if rag_settings["enable_reranking"] is not None:
-            settings_lines.append(
-                f"  enable_reranking          : {rag_settings['enable_reranking']}"
-            )
+            settings_lines.append(f"  enable_reranking          : {rag_settings['enable_reranking']}")
         if rag_settings["similarity_threshold"] is not None:
-            settings_lines.append(
-                f"  similarity_threshold      : {rag_settings['similarity_threshold']}"
-            )
+            settings_lines.append(f"  similarity_threshold      : {rag_settings['similarity_threshold']}")
         if rag_settings["max_chunks"] is not None:
-            settings_lines.append(
-                f"  max_chunks                : {rag_settings['max_chunks']}"
-            )
+            settings_lines.append(f"  max_chunks                : {rag_settings['max_chunks']}")
         if rag_settings["max_tokens_in_context"] is not None:
-            settings_lines.append(
-                f"  max_tokens_in_context     : {rag_settings['max_tokens_in_context']}"
-            )
+            settings_lines.append(f"  max_tokens_in_context     : {rag_settings['max_tokens_in_context']}")
         if rag_settings["refinement_questions_count"] is not None:
-            settings_lines.append(
-                f"  refinement_questions_count: {rag_settings['refinement_questions_count']}"
-            )
+            settings_lines.append(f"  refinement_questions_count: {rag_settings['refinement_questions_count']}")
         if rag_settings["refinement_prompt"] is not None:
             # Truncate prompt if too long
             prompt_preview = rag_settings["refinement_prompt"][:100]
@@ -1426,9 +1367,7 @@ def check_database_status(
     logger.info("Database status check complete")
 
 
-def load_files(
-    content_dir: Path, model: str, pattern: str, force: bool
-) -> list[tuple[Path, Path]]:
+def load_files(content_dir: Path, model: str, pattern: str, force: bool) -> list[tuple[Path, Path]]:
     """Find source files and their corresponding embedding files for loading.
 
     looks for .../doc_dir/source.json files and their
@@ -1456,9 +1395,7 @@ def load_files(
     return valid_pairs
 
 
-def _ensure_database_exists(
-    host: str, port: int, db: str, user: str, password: str
-) -> None:
+def _ensure_database_exists(host: str, port: int, db: str, user: str, password: str) -> None:
     """Ensure the target database exists, create it if it doesn't."""
 
     # Connect to the default postgres database to check/create our target database
@@ -1489,7 +1426,7 @@ def _ensure_database_exists(
 
 
 def load_batch_worker(
-    file_batch: List[str],
+    file_batch: list[str],
     model: str,
     content_dir: str,
     db_host: str,
@@ -1498,7 +1435,7 @@ def load_batch_worker(
     db_user: str,
     db_password: str,
     force: bool,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Worker function for multiprocessing database loading.
 
     Args:
@@ -1564,7 +1501,7 @@ def load_batch_worker(
 
 
 def _load_batch(
-    file_paths: List[Path],
+    file_paths: list[Path],
     model: str,
     content_dir: Path,
     db_host: str,
@@ -1573,7 +1510,7 @@ def _load_batch(
     db_user: str,
     db_password: str,
     force: bool,
-) -> Tuple[int, int]:
+) -> tuple[int, int]:
     """Load a batch of files in a worker process."""
 
     # Create database manager
@@ -1600,16 +1537,18 @@ def _load_batch(
                 continue
 
             # Load embedding data
-            with open(embedding_file, "r", encoding="utf-8") as f:
+            with open(embedding_file, encoding="utf-8") as f:
                 embedding_data = json.load(f)
 
-            files_data.append((
-                source_file,
-                chunks_file,
-                model,
-                embedding_data,
-                embedding_file,
-            ))
+            files_data.append(
+                (
+                    source_file,
+                    chunks_file,
+                    model,
+                    embedding_data,
+                    embedding_file,
+                )
+            )
 
         except Exception as e:
             logger.error(f"Failed to prepare {source_file.name}: {e}")
@@ -1627,17 +1566,17 @@ def load_documents(
     content_dir: str | None = None,
     model: str | None = None,
     pattern: str | None = None,
-    host: Optional[str] = None,
-    port: Optional[int] = None,
-    db: Optional[str] = None,
-    user: Optional[str] = None,
-    password: Optional[str] = None,
+    host: str | None = None,
+    port: int | None = None,
+    db: str | None = None,
+    user: str | None = None,
+    password: str | None = None,
     force: bool = False,
     batch_size: int = 100,
     username: str = "",
-    title: Optional[str] = None,
-    description: Optional[str] = None,
-    note: Optional[str] = None,
+    title: str | None = None,
+    description: str | None = None,
+    note: str | None = None,
 ) -> bool:
     """Load documents and embeddings in the PostgreSQL database.
 
@@ -1721,9 +1660,7 @@ def load_documents(
         result = conn.execute("SELECT title FROM schema_metadata WHERE id = 1")
         row = result.fetchone()
         metadata_exists = row is not None
-        metadata_configured = (
-            metadata_exists and row[0] is not None
-        )  # Has title been set?
+        metadata_configured = metadata_exists and row[0] is not None  # Has title been set?
 
         if metadata_configured:
             # Update existing, configured metadata
@@ -1819,9 +1756,7 @@ def load_documents(
             )
 
             # Build note for this operation
-            operation_note = (
-                note if note else f"Loaded {loaded} files with model {model}"
-            )
+            operation_note = note if note else f"Loaded {loaded} files with model {model}"
             if errors > 0:
                 operation_note += f" ({errors} errors)"
 
@@ -1868,11 +1803,11 @@ def load_documents(
 
 def dump_database(
     output_file: str,
-    host: Optional[str] = None,
-    port: Optional[int] = None,
-    db: Optional[str] = None,
-    user: Optional[str] = None,
-    password: Optional[str] = None,
+    host: str | None = None,
+    port: int | None = None,
+    db: str | None = None,
+    user: str | None = None,
+    password: str | None = None,
     verbose: bool = False,
 ) -> bool:
     """Create a PostgreSQL dump file of the database.
@@ -1950,22 +1885,18 @@ def dump_database(
         logger.error(f"pg_dump failed with exit code {e.returncode}")
         if e.stderr:
             logger.error(f"Error: {e.stderr}")
-        raise DatabaseError(
-            f"Database dump failed with exit code {e.returncode}"
-        ) from e
+        raise DatabaseError(f"Database dump failed with exit code {e.returncode}") from e
     except FileNotFoundError as e:
-        raise ConfigurationError(
-            "pg_dump command not found. Please install PostgreSQL client tools."
-        ) from e
+        raise ConfigurationError("pg_dump command not found. Please install PostgreSQL client tools.") from e
 
 
 def restore_database(
     input_file: str,
-    host: Optional[str] = None,
-    port: Optional[int] = None,
-    db: Optional[str] = None,
-    user: Optional[str] = None,
-    password: Optional[str] = None,
+    host: str | None = None,
+    port: int | None = None,
+    db: str | None = None,
+    user: str | None = None,
+    password: str | None = None,
     verbose: bool = False,
 ) -> bool:
     """Restore a PostgreSQL database from a dump file.
@@ -2038,22 +1969,18 @@ def restore_database(
         logger.error(f"psql failed with exit code {e.returncode}")
         if e.stderr:
             logger.error(f"Error: {e.stderr}")
-        raise DatabaseError(
-            f"Database restore failed with exit code {e.returncode}"
-        ) from e
+        raise DatabaseError(f"Database restore failed with exit code {e.returncode}") from e
     except FileNotFoundError as e:
-        raise ConfigurationError(
-            "psql command not found. Please install PostgreSQL client tools."
-        ) from e
+        raise ConfigurationError("psql command not found. Please install PostgreSQL client tools.") from e
 
 
 def generate_manifest(
     output_file: str = "manifest.txt",
-    host: Optional[str] = None,
-    port: Optional[int] = None,
-    db: Optional[str] = None,
-    user: Optional[str] = None,
-    password: Optional[str] = None,
+    host: str | None = None,
+    port: int | None = None,
+    db: str | None = None,
+    user: str | None = None,
+    password: str | None = None,
 ) -> bool:
     """Generate a manifest file with all unique source files in the database.
 
@@ -2087,18 +2014,18 @@ def generate_manifest(
 
 
 def configure_rag_settings(
-    refinement_prompt: Optional[str] = None,
-    refinement: Optional[str] = None,
-    reranking: Optional[str] = None,
-    similarity_threshold: Optional[str] = None,
-    max_chunks: Optional[str] = None,
-    max_tokens_in_context: Optional[str] = None,
-    refinement_questions_count: Optional[str] = None,
-    host: Optional[str] = None,
-    port: Optional[int] = None,
-    db: Optional[str] = None,
-    user: Optional[str] = None,
-    password: Optional[str] = None,
+    refinement_prompt: str | None = None,
+    refinement: str | None = None,
+    reranking: str | None = None,
+    similarity_threshold: str | None = None,
+    max_chunks: str | None = None,
+    max_tokens_in_context: str | None = None,
+    refinement_questions_count: str | None = None,
+    host: str | None = None,
+    port: int | None = None,
+    db: str | None = None,
+    user: str | None = None,
+    password: str | None = None,
 ) -> None:
     """Configure RAG settings in the database.
 
@@ -2152,9 +2079,7 @@ def configure_rag_settings(
         try:
             return type_func(value), False
         except ValueError:
-            raise ConfigurationError(
-                f"{name}: must be a number or 'None', got '{value}'"
-            )
+            raise ConfigurationError(f"{name}: must be a number or 'None', got '{value}'")
 
     # Parse refinement_prompt (string)
     if refinement_prompt is not None:
@@ -2193,9 +2118,7 @@ def configure_rag_settings(
         clear_flags["max_tokens_in_context"] = clear
 
     if refinement_questions_count is not None:
-        val, clear = parse_number(
-            refinement_questions_count, "--refinement-questions-count", int
-        )
+        val, clear = parse_number(refinement_questions_count, "--refinement-questions-count", int)
         parsed_values["refinement_questions_count"] = val
         clear_flags["refinement_questions_count"] = clear
 
@@ -2211,9 +2134,7 @@ def configure_rag_settings(
     db_user = user if user is not None else config["user"]
     db_password = password if password is not None else config["password"]
 
-    logger.info(
-        f"Updating RAG settings in database: {db_user}@{db_host}:{db_port}/{db_name}"
-    )
+    logger.info(f"Updating RAG settings in database: {db_user}@{db_host}:{db_port}/{db_name}")
 
     # Create database manager
     db_manager = DatabaseManager(
@@ -2240,9 +2161,7 @@ def configure_rag_settings(
         _clear_similarity_threshold=clear_flags.get("similarity_threshold", False),
         _clear_max_chunks=clear_flags.get("max_chunks", False),
         _clear_max_tokens_in_context=clear_flags.get("max_tokens_in_context", False),
-        _clear_refinement_questions_count=clear_flags.get(
-            "refinement_questions_count", False
-        ),
+        _clear_refinement_questions_count=clear_flags.get("refinement_questions_count", False),
     )
 
     logger.info("✅ RAG settings updated successfully")

--- a/src/docs2db/db_lifecycle.py
+++ b/src/docs2db/db_lifecycle.py
@@ -145,7 +145,7 @@ def start_database(profile: str = "prod") -> bool:
             "-d",
         ]
 
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: S603
             cmd,
             capture_output=True,
             text=True,
@@ -199,7 +199,7 @@ def stop_database(profile: str = "prod") -> bool:
             "down",
         ]
 
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: S603
             cmd,
             capture_output=True,
             text=True,
@@ -257,7 +257,7 @@ def destroy_database(profile: str = "prod") -> bool:
 
         cmd = [runtime, "volume", "rm", volume_name]
 
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: S603
             cmd,
             capture_output=True,
             text=True,
@@ -313,7 +313,7 @@ def get_database_logs(follow: bool = False) -> bool:
         cmd.append("db")
 
         # For logs, we want to show output directly to user
-        subprocess.run(cmd, check=True)
+        subprocess.run(cmd, check=True)  # noqa: S603
 
         return True
 

--- a/src/docs2db/db_lifecycle.py
+++ b/src/docs2db/db_lifecycle.py
@@ -2,17 +2,18 @@
 
 import shutil
 import subprocess
+
 from pathlib import Path
-from typing import Optional
 
 import structlog
 
 from docs2db.exceptions import ConfigurationError
 
+
 logger = structlog.get_logger()
 
 
-def detect_container_runtime() -> Optional[str]:
+def detect_container_runtime() -> str | None:
     """Detect available container runtime (podman or docker).
 
     Returns:
@@ -43,10 +44,7 @@ def get_compose_file() -> Path:
         return compose_file
 
     # Offer to create a default compose file
-    logger.info(
-        "No postgres-compose.yml found in current directory. "
-        "Creating a default configuration..."
-    )
+    logger.info("No postgres-compose.yml found in current directory. Creating a default configuration...")
 
     default_compose = """name: docs2db
 
@@ -76,8 +74,7 @@ volumes:
         return compose_file
     except Exception as e:
         raise ConfigurationError(
-            f"Could not create postgres-compose.yml: {e}. "
-            f"Please create one manually or ensure write permissions."
+            f"Could not create postgres-compose.yml: {e}. Please create one manually or ensure write permissions."
         ) from e
 
 
@@ -106,8 +103,7 @@ def get_project_name_from_compose(compose_file: Path) -> str:
                 return name
 
     raise ConfigurationError(
-        f"No 'name:' field found in compose file: {compose_file}. "
-        f"Please add a project name to the compose file."
+        f"No 'name:' field found in compose file: {compose_file}. Please add a project name to the compose file."
     )
 
 
@@ -186,9 +182,7 @@ def stop_database(profile: str = "prod") -> bool:
     runtime = detect_container_runtime()
 
     if not runtime:
-        raise ConfigurationError(
-            "Neither Podman nor Docker found. Cannot stop database."
-        )
+        raise ConfigurationError("Neither Podman nor Docker found. Cannot stop database.")
 
     compose_file = get_compose_file()
 
@@ -242,9 +236,7 @@ def destroy_database(profile: str = "prod") -> bool:
     runtime = detect_container_runtime()
 
     if not runtime:
-        raise ConfigurationError(
-            "Neither Podman nor Docker found. Cannot destroy database."
-        )
+        raise ConfigurationError("Neither Podman nor Docker found. Cannot destroy database.")
 
     compose_file = get_compose_file()
 

--- a/src/docs2db/docs2db.py
+++ b/src/docs2db/docs2db.py
@@ -47,7 +47,7 @@ def ingest(
             raise typer.Exit(1)
     except Docs2DBException as e:
         logger.error(str(e))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
 
 @app.command()
@@ -95,7 +95,7 @@ def chunk(
             raise typer.Exit(1)
     except Docs2DBException as e:
         logger.error(str(e))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
 
 @app.command()
@@ -129,7 +129,7 @@ def embed(
             raise typer.Exit(1)
     except Docs2DBException as e:
         logger.error(str(e))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
 
 @app.command()
@@ -191,7 +191,7 @@ def load(
             raise typer.Exit(1)
     except Docs2DBException as e:
         logger.error(str(e))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
 
 @app.command(name="db-status")
@@ -228,7 +228,7 @@ def db_status(
         )
     except Docs2DBException as e:
         logger.error(str(e))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
 
 @app.command(name="db-dump")
@@ -270,7 +270,7 @@ def db_dump(
             raise typer.Exit(1)
     except Docs2DBException as e:
         logger.error(str(e))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
 
 @app.command(name="db-restore")
@@ -312,7 +312,7 @@ def db_restore(
             raise typer.Exit(1)
     except Docs2DBException as e:
         logger.error(str(e))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
 
 @app.command()
@@ -332,7 +332,7 @@ def audit(
             raise typer.Exit(1)
     except Docs2DBException as e:
         logger.error(str(e))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
 
 @app.command()
@@ -398,7 +398,7 @@ def config(
         )
     except Docs2DBException as e:
         logger.error(str(e))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
 
 @app.command()
@@ -438,7 +438,7 @@ def manifest(
             raise typer.Exit(1)
     except Docs2DBException as e:
         logger.error(str(e))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
 
 @app.command(name="cleanup-workers")
@@ -449,7 +449,7 @@ def cleanup_workers() -> None:
             raise typer.Exit(1)
     except Docs2DBException as e:
         logger.error(str(e))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
 
 @app.command(name="db-start")
@@ -464,7 +464,7 @@ def db_start() -> None:
             raise typer.Exit(1)
     except Docs2DBException as e:
         logger.error(str(e))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
 
 @app.command(name="db-stop")
@@ -478,7 +478,7 @@ def db_stop() -> None:
             raise typer.Exit(1)
     except Docs2DBException as e:
         logger.error(str(e))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
 
 @app.command(name="db-destroy")
@@ -492,7 +492,7 @@ def db_destroy() -> None:
             raise typer.Exit(1)
     except Docs2DBException as e:
         logger.error(str(e))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
 
 @app.command(name="db-logs")
@@ -508,7 +508,7 @@ def db_logs(
             raise typer.Exit(1)
     except Docs2DBException as e:
         logger.error(str(e))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
 
 @app.command()
@@ -658,20 +658,20 @@ def pipeline(
         logger.info("Cleaning up...")
 
         # Try to stop database on failure
-        try:
+        try:  # noqa: SIM105
             stop_database()
-        except Exception:
+        except Exception:  # noqa: S110
             pass  # Ignore cleanup errors
 
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
     except KeyboardInterrupt:
         logger.warning("Pipeline interrupted by user")
         logger.info("Cleaning up...")
 
         # Try to stop database on interrupt
-        try:
+        try:  # noqa: SIM105
             stop_database()
-        except Exception:
+        except Exception:  # noqa: S110
             pass  # Ignore cleanup errors
 
-        raise typer.Exit(130)  # Standard exit code for SIGINT
+        raise typer.Exit(130) from None  # Standard exit code for SIGINT

--- a/src/docs2db/docs2db.py
+++ b/src/docs2db/docs2db.py
@@ -1,31 +1,28 @@
 """RAG Pipeline Tools for docs2db"""
 
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated
 
 import structlog
 import typer
 
 from docs2db.audit import perform_audit
 from docs2db.chunks import generate_chunks
-from docs2db.database import (
-    check_database_status,
-    configure_rag_settings,
-    dump_database,
-    generate_manifest,
-    load_documents,
-    restore_database,
-)
-from docs2db.db_lifecycle import (
-    destroy_database,
-    get_database_logs,
-    start_database,
-    stop_database,
-)
+from docs2db.database import check_database_status
+from docs2db.database import configure_rag_settings
+from docs2db.database import dump_database
+from docs2db.database import generate_manifest
+from docs2db.database import load_documents
+from docs2db.database import restore_database
+from docs2db.db_lifecycle import destroy_database
+from docs2db.db_lifecycle import get_database_logs
+from docs2db.db_lifecycle import start_database
+from docs2db.db_lifecycle import stop_database
 from docs2db.embed import generate_embeddings
 from docs2db.exceptions import Docs2DBException
 from docs2db.ingest import ingest as ingest_command
 from docs2db.utils import cleanup_orphaned_workers
+
 
 logger = structlog.get_logger(__name__)
 
@@ -34,15 +31,9 @@ app = typer.Typer(help="Make a RAG Database from source content")
 
 @app.command()
 def ingest(
-    source_path: Annotated[
-        Optional[str], typer.Argument(help="Path to directory or file to ingest")
-    ],
-    dry_run: Annotated[
-        bool, typer.Option(help="Show what would be processed without doing it")
-    ] = False,
-    force: Annotated[
-        bool, typer.Option(help="Force reprocessing even if files are up-to-date")
-    ] = False,
+    source_path: Annotated[str | None, typer.Argument(help="Path to directory or file to ingest")],
+    dry_run: Annotated[bool, typer.Option(help="Show what would be processed without doing it")] = False,
+    force: Annotated[bool, typer.Option(help="Force reprocessing even if files are up-to-date")] = False,
 ) -> None:
     """Ingest files using docling to create JSON documents in docs2db_content/ directory."""
     if source_path is None:
@@ -61,50 +52,30 @@ def ingest(
 
 @app.command()
 def chunk(
-    content_dir: Annotated[
-        str | None, typer.Option(help="Path to content directory")
-    ] = None,
+    content_dir: Annotated[str | None, typer.Option(help="Path to content directory")] = None,
     pattern: Annotated[
         str,
-        typer.Option(
-            help="Directory pattern (e.g., '**' for all, 'external/**', or 'docs/subdir' for exact path)"
-        ),
+        typer.Option(help="Directory pattern (e.g., '**' for all, 'external/**', or 'docs/subdir' for exact path)"),
     ] = "**",
-    force: Annotated[
-        bool, typer.Option(help="Force reprocessing even if up-to-date")
-    ] = False,
-    dry_run: Annotated[
-        bool, typer.Option(help="Show what would process without doing it")
-    ] = False,
-    skip_context: Annotated[
-        bool | None, typer.Option(help="Skip LLM contextual chunk generation (faster)")
-    ] = None,
-    context_model: Annotated[
-        str | None, typer.Option(help="LLM model for context generation")
-    ] = None,
+    force: Annotated[bool, typer.Option(help="Force reprocessing even if up-to-date")] = False,
+    dry_run: Annotated[bool, typer.Option(help="Show what would process without doing it")] = False,
+    skip_context: Annotated[bool | None, typer.Option(help="Skip LLM contextual chunk generation (faster)")] = None,
+    context_model: Annotated[str | None, typer.Option(help="LLM model for context generation")] = None,
     llm_provider: Annotated[
         str | None,
-        typer.Option(
-            help="LLM provider to use: 'openai' or 'watsonx' (inferred from URL flags if not specified)"
-        ),
+        typer.Option(help="LLM provider to use: 'openai' or 'watsonx' (inferred from URL flags if not specified)"),
     ] = None,
     openai_url: Annotated[
         str | None,
-        typer.Option(
-            help="OpenAI-compatible API URL (default: http://localhost:11434 for Ollama)"
-        ),
+        typer.Option(help="OpenAI-compatible API URL (default: http://localhost:11434 for Ollama)"),
     ] = None,
     watsonx_url: Annotated[
         str | None,
-        typer.Option(
-            help="IBM WatsonX API URL (requires WATSONX_API_KEY and WATSONX_PROJECT_ID env vars)"
-        ),
+        typer.Option(help="IBM WatsonX API URL (requires WATSONX_API_KEY and WATSONX_PROJECT_ID env vars)"),
     ] = None,
     context_limit: Annotated[
         int | None,
-        typer.Option(
-            help="Override model context limit (in tokens) for map-reduce summarization"
-        ),
+        typer.Option(help="Override model context limit (in tokens) for map-reduce summarization"),
     ] = None,
 ) -> None:
     """Generate chunks for content files."""
@@ -129,30 +100,20 @@ def chunk(
 
 @app.command()
 def embed(
-    content_dir: Annotated[
-        str | None, typer.Option(help="Path to content directory")
-    ] = None,
+    content_dir: Annotated[str | None, typer.Option(help="Path to content directory")] = None,
     model: Annotated[
         str | None,
         typer.Option(help="Embedding model to use"),
     ] = None,
     pattern: Annotated[
         str,
-        typer.Option(
-            help="Directory pattern (e.g., '**' for all, 'external/**', or 'docs/subdir' for exact path)"
-        ),
+        typer.Option(help="Directory pattern (e.g., '**' for all, 'external/**', or 'docs/subdir' for exact path)"),
     ] = "**",
-    force: Annotated[
-        bool, typer.Option(help="Force regeneration of existing embeddings")
-    ] = False,
-    dry_run: Annotated[
-        bool, typer.Option(help="Show what would process without doing it")
-    ] = False,
+    force: Annotated[bool, typer.Option(help="Force regeneration of existing embeddings")] = False,
+    dry_run: Annotated[bool, typer.Option(help="Show what would process without doing it")] = False,
     workers: Annotated[
         int | None,
-        typer.Option(
-            help="Max worker processes (1 = single-threaded, avoids fork issues on ARM)"
-        ),
+        typer.Option(help="Max worker processes (1 = single-threaded, avoids fork issues on ARM)"),
     ] = None,
 ) -> None:
     """Generate embeddings for chunked content files."""
@@ -173,59 +134,41 @@ def embed(
 
 @app.command()
 def load(
-    content_dir: Annotated[
-        str | None, typer.Option(help="Path to content directory")
-    ] = None,
+    content_dir: Annotated[str | None, typer.Option(help="Path to content directory")] = None,
     model: Annotated[
         str | None,
-        typer.Option(
-            help="Embedding model to load (e.g., ibm-granite/granite-embedding-30m-english)"
-        ),
+        typer.Option(help="Embedding model to load (e.g., ibm-granite/granite-embedding-30m-english)"),
     ] = None,
     pattern: Annotated[
         str,
-        typer.Option(
-            help="Directory pattern (e.g., '**' for all, 'external/**', or 'docs/subdir' for exact path)"
-        ),
+        typer.Option(help="Directory pattern (e.g., '**' for all, 'external/**', or 'docs/subdir' for exact path)"),
     ] = "**",
-    force: Annotated[
-        bool, typer.Option(help="Force reload of existing documents")
-    ] = False,
+    force: Annotated[bool, typer.Option(help="Force reload of existing documents")] = False,
     host: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Database host (auto-detected from compose file)"),
     ] = None,
     port: Annotated[
-        Optional[int],
+        int | None,
         typer.Option(help="Database port (auto-detected from compose file)"),
     ] = None,
     db: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Database name (auto-detected from compose file)"),
     ] = None,
     user: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Database user (auto-detected from compose file)"),
     ] = None,
     password: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Database password (auto-detected from compose file)"),
     ] = None,
-    batch_size: Annotated[
-        int, typer.Option(help="Files per batch for each worker process")
-    ] = 100,
-    username: Annotated[
-        str, typer.Option(help="Username to record in change log")
-    ] = "",
-    title: Annotated[
-        Optional[str], typer.Option(help="Database title for metadata")
-    ] = None,
-    description: Annotated[
-        Optional[str], typer.Option(help="Database description for metadata")
-    ] = None,
-    note: Annotated[
-        Optional[str], typer.Option(help="Note about this load operation")
-    ] = None,
+    batch_size: Annotated[int, typer.Option(help="Files per batch for each worker process")] = 100,
+    username: Annotated[str, typer.Option(help="Username to record in change log")] = "",
+    title: Annotated[str | None, typer.Option(help="Database title for metadata")] = None,
+    description: Annotated[str | None, typer.Option(help="Database description for metadata")] = None,
+    note: Annotated[str | None, typer.Option(help="Note about this load operation")] = None,
 ) -> None:
     """Load documents, chunks, and embeddings into PostgreSQL database with pgvector."""
     try:
@@ -254,23 +197,23 @@ def load(
 @app.command(name="db-status")
 def db_status(
     host: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Database host (auto-detected from compose file)"),
     ] = None,
     port: Annotated[
-        Optional[int],
+        int | None,
         typer.Option(help="Database port (auto-detected from compose file)"),
     ] = None,
     db: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Database name (auto-detected from compose file)"),
     ] = None,
     user: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Database user (auto-detected from compose file)"),
     ] = None,
     password: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Database password (auto-detected from compose file)"),
     ] = None,
 ) -> None:
@@ -290,27 +233,25 @@ def db_status(
 
 @app.command(name="db-dump")
 def db_dump(
-    output_file: Annotated[
-        str, typer.Option(help="Output file path for the database dump")
-    ] = "ragdb_dump.sql",
+    output_file: Annotated[str, typer.Option(help="Output file path for the database dump")] = "ragdb_dump.sql",
     host: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Database host (auto-detected from compose file)"),
     ] = None,
     port: Annotated[
-        Optional[int],
+        int | None,
         typer.Option(help="Database port (auto-detected from compose file)"),
     ] = None,
     db: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Database name (auto-detected from compose file)"),
     ] = None,
     user: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Database user (auto-detected from compose file)"),
     ] = None,
     password: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Database password (auto-detected from compose file)"),
     ] = None,
     verbose: Annotated[bool, typer.Option(help="Show pg_dump output")] = False,
@@ -334,27 +275,25 @@ def db_dump(
 
 @app.command(name="db-restore")
 def db_restore(
-    input_file: Annotated[
-        str, typer.Argument(help="Input file path for the database dump")
-    ],
+    input_file: Annotated[str, typer.Argument(help="Input file path for the database dump")],
     host: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Database host (auto-detected from compose file)"),
     ] = None,
     port: Annotated[
-        Optional[int],
+        int | None,
         typer.Option(help="Database port (auto-detected from compose file)"),
     ] = None,
     db: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Database name (auto-detected from compose file)"),
     ] = None,
     user: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Database user (auto-detected from compose file)"),
     ] = None,
     password: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Database password (auto-detected from compose file)"),
     ] = None,
     verbose: Annotated[bool, typer.Option(help="Show psql output")] = False,
@@ -378,14 +317,10 @@ def db_restore(
 
 @app.command()
 def audit(
-    content_dir: Annotated[
-        str | None, typer.Option(help="Path to content directory")
-    ] = None,
+    content_dir: Annotated[str | None, typer.Option(help="Path to content directory")] = None,
     pattern: Annotated[
         str,
-        typer.Option(
-            help="Directory pattern to audit (e.g., 'external/**' or 'additional_documents/*')"
-        ),
+        typer.Option(help="Directory pattern to audit (e.g., 'external/**' or 'additional_documents/*')"),
     ] = "**",
 ) -> None:
     """Audit to find missing and stale files."""
@@ -403,37 +338,35 @@ def audit(
 @app.command()
 def config(
     refinement_prompt: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Custom prompt for query refinement (use 'None' to clear)"),
     ] = None,
-    refinement: Annotated[
-        Optional[str], typer.Option(help="Enable question refinement: true/false/None")
-    ] = None,
+    refinement: Annotated[str | None, typer.Option(help="Enable question refinement: true/false/None")] = None,
     reranking: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Enable cross-encoder reranking: true/false/None"),
     ] = None,
     similarity_threshold: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Similarity threshold 0.0-1.0 (use 'None' to clear)"),
     ] = None,
     max_chunks: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Maximum chunks to return (use 'None' to clear)"),
     ] = None,
     max_tokens_in_context: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Maximum tokens in context (use 'None' to clear)"),
     ] = None,
     refinement_questions_count: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Number of refined questions (use 'None' to clear)"),
     ] = None,
-    host: Annotated[Optional[str], typer.Option(help="Database host")] = None,
-    port: Annotated[Optional[int], typer.Option(help="Database port")] = None,
-    db: Annotated[Optional[str], typer.Option(help="Database name")] = None,
-    user: Annotated[Optional[str], typer.Option(help="Database user")] = None,
-    password: Annotated[Optional[str], typer.Option(help="Database password")] = None,
+    host: Annotated[str | None, typer.Option(help="Database host")] = None,
+    port: Annotated[int | None, typer.Option(help="Database port")] = None,
+    db: Annotated[str | None, typer.Option(help="Database name")] = None,
+    user: Annotated[str | None, typer.Option(help="Database user")] = None,
+    password: Annotated[str | None, typer.Option(help="Database password")] = None,
 ) -> None:
     """Configure RAG settings in the database.
 
@@ -470,27 +403,25 @@ def config(
 
 @app.command()
 def manifest(
-    output_file: Annotated[
-        str, typer.Option(help="Output file path for the manifest")
-    ] = "manifest.txt",
+    output_file: Annotated[str, typer.Option(help="Output file path for the manifest")] = "manifest.txt",
     host: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Database host (auto-detected from compose file)"),
     ] = None,
     port: Annotated[
-        Optional[int],
+        int | None,
         typer.Option(help="Database port (auto-detected from compose file)"),
     ] = None,
     db: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Database name (auto-detected from compose file)"),
     ] = None,
     user: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Database user (auto-detected from compose file)"),
     ] = None,
     password: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Database password (auto-detected from compose file)"),
     ] = None,
 ) -> None:
@@ -566,9 +497,7 @@ def db_destroy() -> None:
 
 @app.command(name="db-logs")
 def db_logs(
-    follow: Annotated[
-        bool, typer.Option("--follow", "-f", help="Follow logs in real-time")
-    ] = False,
+    follow: Annotated[bool, typer.Option("--follow", "-f", help="Follow logs in real-time")] = False,
 ) -> None:
     """View PostgreSQL database logs.
 
@@ -585,58 +514,34 @@ def db_logs(
 @app.command()
 def pipeline(
     source_path: Annotated[
-        Optional[str],
+        str | None,
         typer.Argument(help="Path to source directory or file to process"),
     ],
-    content_dir: Annotated[
-        str | None, typer.Option(help="Content directory for intermediate files")
-    ] = None,
+    content_dir: Annotated[str | None, typer.Option(help="Content directory for intermediate files")] = None,
     model: Annotated[str | None, typer.Option(help="Embedding model to use")] = None,
-    skip_context: Annotated[
-        bool, typer.Option(help="Skip LLM contextual chunk generation (faster)")
-    ] = False,
-    context_model: Annotated[
-        str | None, typer.Option(help="LLM model for context generation")
-    ] = None,
+    skip_context: Annotated[bool, typer.Option(help="Skip LLM contextual chunk generation (faster)")] = False,
+    context_model: Annotated[str | None, typer.Option(help="LLM model for context generation")] = None,
     llm_provider: Annotated[
         str | None,
-        typer.Option(
-            help="LLM provider to use: 'openai' or 'watsonx' (inferred from URL flags if not specified)"
-        ),
+        typer.Option(help="LLM provider to use: 'openai' or 'watsonx' (inferred from URL flags if not specified)"),
     ] = None,
     openai_url: Annotated[
         str | None,
-        typer.Option(
-            help="OpenAI-compatible API URL (default: http://localhost:11434 for Ollama)"
-        ),
+        typer.Option(help="OpenAI-compatible API URL (default: http://localhost:11434 for Ollama)"),
     ] = None,
     watsonx_url: Annotated[
         str | None,
-        typer.Option(
-            help="IBM WatsonX API URL (requires WATSONX_API_KEY and WATSONX_PROJECT_ID env vars)"
-        ),
+        typer.Option(help="IBM WatsonX API URL (requires WATSONX_API_KEY and WATSONX_PROJECT_ID env vars)"),
     ] = None,
     context_limit: Annotated[
         int | None,
-        typer.Option(
-            help="Override model context limit (in tokens) for map-reduce summarization"
-        ),
+        typer.Option(help="Override model context limit (in tokens) for map-reduce summarization"),
     ] = None,
-    output_file: Annotated[
-        str, typer.Option(help="Output SQL dump file")
-    ] = "ragdb_dump.sql",
-    username: Annotated[
-        str, typer.Option(help="Username to record in change log")
-    ] = "",
-    title: Annotated[
-        Optional[str], typer.Option(help="Database title for metadata")
-    ] = None,
-    description: Annotated[
-        Optional[str], typer.Option(help="Database description for metadata")
-    ] = None,
-    note: Annotated[
-        Optional[str], typer.Option(help="Note about this load operation")
-    ] = None,
+    output_file: Annotated[str, typer.Option(help="Output SQL dump file")] = "ragdb_dump.sql",
+    username: Annotated[str, typer.Option(help="Username to record in change log")] = "",
+    title: Annotated[str | None, typer.Option(help="Database title for metadata")] = None,
+    description: Annotated[str | None, typer.Option(help="Database description for metadata")] = None,
+    note: Annotated[str | None, typer.Option(help="Note about this load operation")] = None,
 ) -> None:
     """Run complete docs2db pipeline: start DB → ingest → chunk → embed → load → dump → stop.
 

--- a/src/docs2db/embed.py
+++ b/src/docs2db/embed.py
@@ -3,6 +3,7 @@
 import os
 import signal
 import time
+
 from pathlib import Path
 from typing import Any
 
@@ -10,8 +11,11 @@ import psutil
 import structlog
 
 from docs2db.config import settings
-from docs2db.embeddings import Embedding, get_optimal_device
-from docs2db.multiproc import BatchProcessor, setup_worker_logging
+from docs2db.embeddings import Embedding
+from docs2db.embeddings import get_optimal_device
+from docs2db.multiproc import BatchProcessor
+from docs2db.multiproc import setup_worker_logging
+
 
 logger = structlog.get_logger(__name__)
 

--- a/src/docs2db/embeddings.py
+++ b/src/docs2db/embeddings.py
@@ -54,10 +54,7 @@ def is_embedding_stale(
         # Check if model or dimensions have changed
         if metadata.get("model") != model:
             return True
-        if metadata.get("dimensions") != dimensions:
-            return True
-
-        return False
+        return metadata.get("dimensions") != dimensions
 
     except (json.JSONDecodeError, KeyError, ValueError, FileNotFoundError):
         return True

--- a/src/docs2db/embeddings.py
+++ b/src/docs2db/embeddings.py
@@ -2,13 +2,17 @@
 
 import json
 import warnings
-from datetime import datetime, timezone
+
+from datetime import datetime
+from datetime import UTC
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import structlog
 
-from docs2db.utils import ensure_model_available, hash_file
+from docs2db.utils import ensure_model_available
+from docs2db.utils import hash_file
+
 
 logger = structlog.get_logger(__name__)
 
@@ -111,7 +115,7 @@ class Embedding:
         self.device = get_optimal_device()
 
         if self.device == "cpu":
-            logger.warning(f"Using CPU to generate embeddings. May be slow.")
+            logger.warning("Using CPU to generate embeddings. May be slow.")
 
         # Lazy-loaded provider
         self._provider = None
@@ -141,18 +145,14 @@ class Embedding:
         if self._provider is None:
             # Suppress transformers warnings when creating providers
             warnings.filterwarnings("ignore", category=FutureWarning, module="torch")
-            warnings.filterwarnings(
-                "ignore", category=FutureWarning, module="transformers"
-            )
+            warnings.filterwarnings("ignore", category=FutureWarning, module="transformers")
             warnings.filterwarnings(
                 "ignore",
                 message=".*encoder_attention_mask.*is deprecated.*",
                 category=FutureWarning,
             )
 
-            self._provider = self.provider_cls(
-                self.model, self.dimensions, self.batch_size, self.device
-            )
+            self._provider = self.provider_cls(self.model, self.dimensions, self.batch_size, self.device)
 
         return self._provider
 
@@ -165,7 +165,7 @@ class Embedding:
             self.dimensions,
         )
 
-    def _load_chunks(self, chunks_file: Path) -> Tuple[List[str], Dict[str, Any]]:
+    def _load_chunks(self, chunks_file: Path) -> tuple[list[str], dict[str, Any]]:
         """Load chunks from a .chunks.json file."""
         try:
             with open(chunks_file) as f:
@@ -184,9 +184,9 @@ class Embedding:
     def _save_embeddings_file(
         self,
         file: Path,
-        embeddings: List[List[float]],
-        chunks: List[str],
-        source_metadata: Dict[str, Any],
+        embeddings: list[list[float]],
+        chunks: list[str],
+        source_metadata: dict[str, Any],
         chunks_file: Path,
     ) -> None:
         """Save embeddings to file with metadata."""
@@ -200,7 +200,7 @@ class Embedding:
                     "chunks_hash": chunks_hash,
                     "model": self.model,
                     "dimensions": self.dimensions,
-                    "embedded_at": datetime.now(timezone.utc).isoformat(),
+                    "embedded_at": datetime.now(UTC).isoformat(),
                     "count": len(embeddings),
                     "chunks": {
                         "chunk_count": len(chunks),
@@ -219,9 +219,7 @@ class Embedding:
                 file.unlink()
             raise
 
-    def generate_embedding(
-        self, chunks_file: str | Path, force: bool = False
-    ) -> Optional[Path]:
+    def generate_embedding(self, chunks_file: str | Path, force: bool = False) -> Path | None:
         """Generate embeddings for a chunks file - handles everything!"""
         chunks_file = Path(chunks_file)
         embeddings_file = create_embedding_filename(chunks_file, self.model)
@@ -238,9 +236,7 @@ class Embedding:
         provider = self._get_provider()
         embeddings = provider.generate_embeddings(chunks)
 
-        self._save_embeddings_file(
-            embeddings_file, embeddings, chunks, source_metadata, chunks_file
-        )
+        self._save_embeddings_file(embeddings_file, embeddings, chunks, source_metadata, chunks_file)
 
         return embeddings_file
 
@@ -262,7 +258,7 @@ class EmbeddingProvider:
         self.batch_size = batch_size
         self.device = device
 
-    def generate_embeddings(self, texts: List[str]) -> List[List[float]]:
+    def generate_embeddings(self, texts: list[str]) -> list[list[float]]:
         """Generate embeddings for a list of texts."""
         raise NotImplementedError
 
@@ -279,23 +275,18 @@ class GraniteEmbeddingProvider(EmbeddingProvider):
         """Get or create the Granite model and tokenizer."""
         if self._model is None or self._tokenizer is None:
             try:
-                from transformers import AutoModel, AutoTokenizer
+                from transformers import AutoModel
+                from transformers import AutoTokenizer
 
                 # Set MPS memory limits to prevent memory leaks
                 if self.device == "mps":
                     import torch
 
-                    torch.mps.set_per_process_memory_fraction(
-                        0.4
-                    )  # Limit to 40% of memory per worker
+                    torch.mps.set_per_process_memory_fraction(0.4)  # Limit to 40% of memory per worker
 
                 try:
-                    self._model = AutoModel.from_pretrained(
-                        self.model, local_files_only=True
-                    )
-                    self._tokenizer = AutoTokenizer.from_pretrained(
-                        self.model, local_files_only=True
-                    )
+                    self._model = AutoModel.from_pretrained(self.model, local_files_only=True)
+                    self._tokenizer = AutoTokenizer.from_pretrained(self.model, local_files_only=True)
                 except Exception as e:
                     raise ValueError(
                         f"Granite model '{self.model}' not found locally. "
@@ -313,7 +304,7 @@ class GraniteEmbeddingProvider(EmbeddingProvider):
                 ) from None
         return self._model, self._tokenizer
 
-    def _get_embedding_batch(self, texts: List[str]) -> List[List[float]]:
+    def _get_embedding_batch(self, texts: list[str]) -> list[list[float]]:
         """Get embeddings for a batch of texts using CLS token pooling."""
         import gc
 
@@ -361,7 +352,7 @@ class GraniteEmbeddingProvider(EmbeddingProvider):
 
         return result
 
-    def generate_embeddings(self, texts: List[str]) -> List[List[float]]:
+    def generate_embeddings(self, texts: list[str]) -> list[list[float]]:
         """Generate embeddings using Granite model with CLS pooling."""
         # Process in batches
         all_embeddings = []
@@ -376,7 +367,7 @@ class GraniteEmbeddingProvider(EmbeddingProvider):
 class WatsonEmbeddingProvider(EmbeddingProvider):
     """Watson embedding provider - placeholder for now."""
 
-    def generate_embeddings(self, texts: List[str]) -> List[List[float]]:
+    def generate_embeddings(self, texts: list[str]) -> list[list[float]]:
         """Generate embeddings using Watson."""
         # TODO: Implement based on existing WatsonEmbeddingProvider
         raise NotImplementedError("Watson provider implementation needed")
@@ -385,18 +376,16 @@ class WatsonEmbeddingProvider(EmbeddingProvider):
 class SentenceTransformerProvider(EmbeddingProvider):
     """Sentence Transformers provider - placeholder for now."""
 
-    def generate_embeddings(self, texts: List[str]) -> List[List[float]]:
+    def generate_embeddings(self, texts: list[str]) -> list[list[float]]:
         """Generate embeddings using Sentence Transformers."""
         # TODO: Implement based on existing SentenceTransformerProvider
-        raise NotImplementedError(
-            "Sentence Transformers provider implementation needed"
-        )
+        raise NotImplementedError("Sentence Transformers provider implementation needed")
 
 
 class NoInstructEmbeddingProvider(EmbeddingProvider):
     """NoInstruct embedding provider - placeholder for now."""
 
-    def generate_embeddings(self, texts: List[str]) -> List[List[float]]:
+    def generate_embeddings(self, texts: list[str]) -> list[list[float]]:
         """Generate embeddings using NoInstruct model."""
         # TODO: Implement based on existing NoInstructEmbeddingProvider
         raise NotImplementedError("NoInstruct provider implementation needed")
@@ -405,7 +394,7 @@ class NoInstructEmbeddingProvider(EmbeddingProvider):
 class E5EmbeddingProvider(EmbeddingProvider):
     """E5 embedding provider - placeholder for now."""
 
-    def generate_embeddings(self, texts: List[str]) -> List[List[float]]:
+    def generate_embeddings(self, texts: list[str]) -> list[list[float]]:
         """Generate embeddings using E5 model."""
         # TODO: Implement based on existing E5EmbeddingProvider
         raise NotImplementedError("E5 provider implementation needed")

--- a/src/docs2db/ingest.py
+++ b/src/docs2db/ingest.py
@@ -5,22 +5,29 @@ import logging
 import mimetypes
 import os
 import time
-from datetime import datetime, timezone
+
+from collections.abc import Iterator
+from datetime import datetime
+from datetime import UTC
 from importlib.metadata import version
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any
 
 import psutil
 import structlog
+
 from docling.document_converter import DocumentConverter
 from docling_core.types.io import DocumentStream
 
 from docs2db.config import settings
 from docs2db.const import METADATA_SCHEMA_VERSION
 from docs2db.exceptions import Docs2DBException
-from docs2db.multiproc import BatchProcessor, setup_worker_logging
-from docs2db.utils import hash_bytes, hash_file
+from docs2db.multiproc import BatchProcessor
+from docs2db.multiproc import setup_worker_logging
+from docs2db.utils import hash_bytes
+from docs2db.utils import hash_file
+
 
 logger = structlog.get_logger(__name__)
 
@@ -355,9 +362,7 @@ def document_needs_update(
         if stored_hash is None:
             # Have content but no stored hash - needs update
             return True
-        current_hash = hash_bytes(
-            content if isinstance(content, bytes) else content.encode("utf-8")
-        )
+        current_hash = hash_bytes(content if isinstance(content, bytes) else content.encode("utf-8"))
         if current_hash != stored_hash:
             # Hash differs - needs update
             return True
@@ -475,9 +480,7 @@ def ingest_from_content(
         return True
 
     except Exception as e:
-        logger.error(
-            "Failed to convert content", target=str(content_path), error=str(e)
-        )
+        logger.error("Failed to convert content", target=str(content_path), error=str(e))
         return False
 
 
@@ -498,7 +501,7 @@ def generate_metadata(
     metadata: dict[str, Any] = {
         "metadata_version": METADATA_SCHEMA_VERSION,
         "processing": {
-            "ingested_at": datetime.now(timezone.utc).isoformat(),
+            "ingested_at": datetime.now(UTC).isoformat(),
             "source_hash": source_hash,
             "docling_version": version("docling"),
         },
@@ -524,7 +527,7 @@ def generate_metadata(
         filesystem_meta = {
             "original_path": str(relative_path.with_suffix(source_file.suffix)),
             "size_bytes": stat.st_size,
-            "mtime": datetime.fromtimestamp(stat.st_mtime, timezone.utc).isoformat(),
+            "mtime": datetime.fromtimestamp(stat.st_mtime, UTC).isoformat(),
         }
         mime, _ = mimetypes.guess_type(source_file)
         if mime:
@@ -546,9 +549,7 @@ def generate_metadata(
         if content_meta:
             metadata["content"] = content_meta
     except (OSError, json.JSONDecodeError) as e:
-        logger.warning(
-            f"Could not read docling document for metadata from {content_path}: {e}"
-        )
+        logger.warning(f"Could not read docling document for metadata from {content_path}: {e}")
 
     if source_metadata:
         metadata["source"] = source_metadata
@@ -602,9 +603,7 @@ def ingest(source_path: str, dry_run: bool = False, force: bool = False) -> bool
         logger.info("Dry run mode - would process:")
         for source_file in source_files:
             content_path = generate_content_path(source_file, source_root)
-            logger.info(
-                source_file.name, source=str(source_file), target=str(content_path)
-            )
+            logger.info(source_file.name, source=str(source_file), target=str(content_path))
         return True
 
     # Use multiprocessing for ingestion

--- a/src/docs2db/multiproc.py
+++ b/src/docs2db/multiproc.py
@@ -133,10 +133,7 @@ class ProgressDisplay(Live):
         pre = f"Worker {worker_id:>2}: "
         available_width = terminal_width - len(pre) - 4
 
-        if len(status) > available_width:
-            trim_status = status[: available_width - 3] + "..."
-        else:
-            trim_status = status
+        trim_status = status[: available_width - 3] + "..." if len(status) > available_width else status
 
         self.worker_lines[worker_id] = Text(f"{pre}{trim_status}", style="dim")
 
@@ -307,8 +304,8 @@ class BatchProcessor:
 
     def _prime_worker_pool(self, batches):
         """Submit initial batches to all available workers."""
-        assert isinstance(self.display, ProgressDisplay)
-        assert isinstance(self.max_workers, int)
+        assert isinstance(self.display, ProgressDisplay)  # noqa: S101
+        assert isinstance(self.max_workers, int)  # noqa: S101
         for worker_id in range(self.max_workers):
             self._submit_batch_to_worker(worker_id, batches)
         self.display.refresh_display()
@@ -319,8 +316,8 @@ class BatchProcessor:
         Returns True if batch was submitted.
 
         """
-        assert isinstance(self.display, ProgressDisplay)
-        assert isinstance(self.executor, ProcessPoolExecutor)
+        assert isinstance(self.display, ProgressDisplay)  # noqa: S101
+        assert isinstance(self.executor, ProcessPoolExecutor)  # noqa: S101
         try:
             batch = next(batches)
             self.display.set_worker_status(worker_id, f"processing {batch[0]}")
@@ -377,7 +374,7 @@ class BatchProcessor:
 
     def _process_successful_result(self, result, worker_id: int, batch):
         """Update logs and displays for a successful batch result."""
-        assert isinstance(self.display, ProgressDisplay)
+        assert isinstance(self.display, ProgressDisplay)  # noqa: S101
         # Replay worker logs
         for log_entry in result["worker_logs"]:
             logger.log(
@@ -395,7 +392,7 @@ class BatchProcessor:
 
     def _process_failed_result(self, error, worker_id: int, batch):
         """Update error tracking and displays for a failed batch result."""
-        assert isinstance(self.display, ProgressDisplay)
+        assert isinstance(self.display, ProgressDisplay)  # noqa: S101
 
         # Log detailed error information
         logger.error(
@@ -420,8 +417,8 @@ class BatchProcessor:
 
     def _restart_workers(self, batches):
         """Restart all workers to clear memory."""
-        assert isinstance(self.display, ProgressDisplay)
-        assert isinstance(self.executor, ProcessPoolExecutor)
+        assert isinstance(self.display, ProgressDisplay)  # noqa: S101
+        assert isinstance(self.executor, ProcessPoolExecutor)  # noqa: S101
         # Complete remaining futures before restart
         remaining_futures = list(self.futures.keys())
         if remaining_futures:
@@ -435,7 +432,7 @@ class BatchProcessor:
         self.futures = {}
 
         # Update worker statuses
-        assert isinstance(self.max_workers, int)
+        assert isinstance(self.max_workers, int)  # noqa: S101
         for worker_id in range(self.max_workers):
             self.display.set_worker_status(worker_id, "restarted")
         self.display.refresh_display()
@@ -443,7 +440,7 @@ class BatchProcessor:
 
     def _complete_remaining_futures(self, remaining_futures):
         """Complete all remaining futures before worker restart."""
-        assert isinstance(self.display, ProgressDisplay)
+        assert isinstance(self.display, ProgressDisplay)  # noqa: S101
         for future in as_completed(remaining_futures):
             if future in self.futures:
                 worker_id, batch = self.futures.pop(future)
@@ -473,7 +470,7 @@ class BatchProcessor:
 
     def _update_display(self):
         """Update the progress display."""
-        assert isinstance(self.display, ProgressDisplay)
+        assert isinstance(self.display, ProgressDisplay)  # noqa: S101
         self.display.update_progress(
             completed=self.processed,
             errors=self.errors,

--- a/src/docs2db/multiproc.py
+++ b/src/docs2db/multiproc.py
@@ -2,22 +2,24 @@
 
 import logging
 import os
-from concurrent.futures import ProcessPoolExecutor, as_completed
+
+from concurrent.futures import as_completed
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
-from typing import Optional
 
 import structlog
-from rich.console import Console, Group
+
+from rich.console import Console
+from rich.console import Group
 from rich.live import Live
 from rich.logging import RichHandler
-from rich.progress import (
-    BarColumn,
-    Progress,
-    SpinnerColumn,
-    TextColumn,
-    TimeRemainingColumn,
-)
+from rich.progress import BarColumn
+from rich.progress import Progress
+from rich.progress import SpinnerColumn
+from rich.progress import TextColumn
+from rich.progress import TimeRemainingColumn
 from rich.text import Text
+
 
 logger = structlog.get_logger(__name__)
 
@@ -46,8 +48,8 @@ def batch_generator(files: list[Path], batch_size: int):
 
 def worker_count(
     total_files: int,
-    max_workers: Optional[int] = None,
-    max_workers_config: Optional[int] = None,
+    max_workers: int | None = None,
+    max_workers_config: int | None = None,
 ) -> int:
     """Determine optimal number of workers for processing.
 
@@ -170,7 +172,7 @@ class BatchProcessor:
         progress_message: str,
         batch_size: int,
         mem_threshold_mb: int,
-        max_workers: Optional[int] = None,
+        max_workers: int | None = None,
     ):
         self.worker_function = worker_function
         self.worker_args = worker_args
@@ -184,8 +186,8 @@ class BatchProcessor:
         self.errors = 0
         self.error_data = []
         self.futures = {}
-        self.executor: Optional[ProcessPoolExecutor] = None
-        self.display: Optional[ProgressDisplay] = None
+        self.executor: ProcessPoolExecutor | None = None
+        self.display: ProgressDisplay | None = None
         self.console = Console()
 
     def process_files(
@@ -210,15 +212,11 @@ class BatchProcessor:
 
         batches = batch_generator(to_process, self.batch_size)
 
-        self.console.print(
-            f"[blue]Processing {count} files using {self.max_workers} workers[/blue]"
-        )
+        self.console.print(f"[blue]Processing {count} files using {self.max_workers} workers[/blue]")
 
         self._setup_logging()
 
-        with ProgressDisplay(
-            self.console, self.max_workers, count, self.progress_message
-        ) as display:
+        with ProgressDisplay(self.console, self.max_workers, count, self.progress_message) as display:
             self.display = display
             self.executor = ProcessPoolExecutor(max_workers=self.max_workers)
 
@@ -249,9 +247,7 @@ class BatchProcessor:
             tuple[int, int]: (num_processed, num_failed)
         """
         count = len(to_process)
-        self.console.print(
-            f"[blue]Processing {count} files in single-threaded mode[/blue]"
-        )
+        self.console.print(f"[blue]Processing {count} files in single-threaded mode[/blue]")
 
         batches = list(batch_generator(to_process, self.batch_size))
 
@@ -328,9 +324,7 @@ class BatchProcessor:
         try:
             batch = next(batches)
             self.display.set_worker_status(worker_id, f"processing {batch[0]}")
-            future = self.executor.submit(
-                self.worker_function, batch, *self.worker_args
-            )
+            future = self.executor.submit(self.worker_function, batch, *self.worker_args)
             self.futures[future] = worker_id, batch
             return True
         except StopIteration:
@@ -460,9 +454,7 @@ class BatchProcessor:
                     self.processed += len(batch)
                     self.errors += result["errors"]
                     self.error_data.extend(result["error_data"])
-                    self.display.set_worker_status(
-                        worker_id, "completed before restart"
-                    )
+                    self.display.set_worker_status(worker_id, "completed before restart")
                 except Exception as e:
                     for file in batch:
                         self.error_data.append({"file": file, "error": e})
@@ -503,15 +495,17 @@ class LogCollector:
         self.logs = []
 
     def handle(self, record):
-        self.logs.append({
-            "level": record.levelno,
-            "levelname": record.levelname,
-            "message": record.getMessage(),
-            "name": record.name,
-            "timestamp": record.created,
-            "pathname": getattr(record, "pathname", ""),
-            "lineno": getattr(record, "lineno", 0),
-        })
+        self.logs.append(
+            {
+                "level": record.levelno,
+                "levelname": record.levelname,
+                "message": record.getMessage(),
+                "name": record.name,
+                "timestamp": record.created,
+                "pathname": getattr(record, "pathname", ""),
+                "lineno": getattr(record, "lineno", 0),
+            }
+        )
 
 
 class WorkerLogHandler(logging.Handler):

--- a/src/docs2db/utils.py
+++ b/src/docs2db/utils.py
@@ -71,7 +71,7 @@ def cleanup_orphaned_workers() -> bool:
         ConfigurationError: If system commands are not available
     """
     try:
-        result = subprocess.run(["ps", "aux"], capture_output=True, text=True, check=True)
+        result = subprocess.run(["ps", "aux"], capture_output=True, text=True, check=True)  # noqa: S607
 
         orphaned_processes = []
         current_pid = os.getpid()

--- a/src/docs2db/utils.py
+++ b/src/docs2db/utils.py
@@ -4,13 +4,17 @@ import os
 import signal
 import subprocess
 import time
+
 from pathlib import Path
 
 import structlog
 import xxhash
-from transformers import AutoModel, AutoTokenizer
+
+from transformers import AutoModel
+from transformers import AutoTokenizer
 
 from docs2db.exceptions import ConfigurationError
+
 
 logger = structlog.get_logger(__name__)
 
@@ -54,9 +58,7 @@ def ensure_model_available(model_id: str) -> None:
             AutoTokenizer.from_pretrained(model_id, local_files_only=True)
         except Exception as download_error:
             logger.error(f"Failed to download {model_id}: {download_error}")
-            raise ConfigurationError(
-                f"Failed to download model {model_id}: {download_error}"
-            ) from download_error
+            raise ConfigurationError(f"Failed to download model {model_id}: {download_error}") from download_error
 
 
 def cleanup_orphaned_workers() -> bool:
@@ -69,9 +71,7 @@ def cleanup_orphaned_workers() -> bool:
         ConfigurationError: If system commands are not available
     """
     try:
-        result = subprocess.run(
-            ["ps", "aux"], capture_output=True, text=True, check=True
-        )
+        result = subprocess.run(["ps", "aux"], capture_output=True, text=True, check=True)
 
         orphaned_processes = []
         current_pid = os.getpid()
@@ -134,9 +134,7 @@ def cleanup_orphaned_workers() -> bool:
                 pass
 
         # Step 4: SIGKILL any remaining processes
-        killed_count = len(pids_to_kill) - len(
-            still_alive
-        )  # Processes that responded to SIGTERM
+        killed_count = len(pids_to_kill) - len(still_alive)  # Processes that responded to SIGTERM
 
         if still_alive:
             logger.info(f"Force-killing {len(still_alive)} unresponsive processes...")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,12 @@
 
 import psycopg
 import pytest
-from psycopg.sql import SQL, Identifier
 
-from tests.test_config import get_test_db_config, should_skip_postgres_tests
+from psycopg.sql import Identifier
+from psycopg.sql import SQL
+
+from tests.test_config import get_test_db_config
+from tests.test_config import should_skip_postgres_tests
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -25,9 +28,7 @@ def setup_clean_database():
 
     with psycopg.Connection.connect(admin_conn_string, autocommit=True) as conn:
         # Drop test database if it exists
-        conn.execute(
-            SQL("DROP DATABASE IF EXISTS {}").format(Identifier(config["database"]))
-        )
+        conn.execute(SQL("DROP DATABASE IF EXISTS {}").format(Identifier(config["database"])))
         # Create fresh test database
         conn.execute(SQL("CREATE DATABASE {}").format(Identifier(config["database"])))
 
@@ -35,6 +36,4 @@ def setup_clean_database():
 
     # Cleanup after all tests
     with psycopg.Connection.connect(admin_conn_string, autocommit=True) as conn:
-        conn.execute(
-            SQL("DROP DATABASE IF EXISTS {}").format(Identifier(config["database"]))
-        )
+        conn.execute(SQL("DROP DATABASE IF EXISTS {}").format(Identifier(config["database"])))

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -29,7 +29,7 @@ def check_table_exists(conn, table_name: str) -> bool:
 def count_records(conn, table_name: str) -> int:
     """Count records in a table."""
     with conn.cursor() as cur:
-        cur.execute(f"SELECT COUNT(*) FROM {table_name}")
+        cur.execute(f"SELECT COUNT(*) FROM {table_name}")  # noqa: S608
         result = cur.fetchone()
         return result[0] if result else 0
 
@@ -78,7 +78,7 @@ class TestCLIIntegrationSQL:
                 "--force",  # Force to ensure it processes our test file
             ]
 
-            result = subprocess.run(
+            result = subprocess.run(  # noqa: S603
                 cmd,
                 capture_output=True,
                 text=True,
@@ -128,7 +128,7 @@ class TestCLIIntegrationSQL:
             # Test 1: Database server down (wrong port)
             cmd_base = ["uv", "run", "docs2db", "db-status"]
 
-            result = subprocess.run(
+            result = subprocess.run(  # noqa: S603
                 cmd_base
                 + [
                     "--host",
@@ -156,7 +156,7 @@ class TestCLIIntegrationSQL:
             )
 
             # Test 2: Server up but database doesn't exist
-            result = subprocess.run(
+            result = subprocess.run(  # noqa: S603
                 cmd_base
                 + [
                     "--host",
@@ -181,7 +181,7 @@ class TestCLIIntegrationSQL:
             )
 
             # Test 3: Database exists but is not initialized
-            result = subprocess.run(
+            result = subprocess.run(  # noqa: S603
                 cmd_base
                 + [
                     "--host",
@@ -214,8 +214,8 @@ class TestCLIIntegrationSQL:
             import tempfile
 
             with tempfile.TemporaryDirectory() as empty_dir:
-                load_result = subprocess.run(
-                    [
+                load_result = subprocess.run(  # noqa: S603
+                    [  # noqa: S607
                         "uv",
                         "run",
                         "docs2db",
@@ -245,7 +245,7 @@ class TestCLIIntegrationSQL:
                 )
 
             # Now test db-status - should show initialized database with 0 counts
-            result = subprocess.run(
+            result = subprocess.run(  # noqa: S603
                 cmd_base
                 + [
                     "--host",
@@ -272,8 +272,8 @@ class TestCLIIntegrationSQL:
             # Test 5: Database with actual data
             fixtures_content_dir = Path(__file__).parent / "fixtures" / "content" / "documents"
 
-            load_result = subprocess.run(
-                [
+            load_result = subprocess.run(  # noqa: S603
+                [  # noqa: S607
                     "uv",
                     "run",
                     "docs2db",
@@ -301,7 +301,7 @@ class TestCLIIntegrationSQL:
             assert load_result.returncode == 0, f"Load should succeed: {load_result.stdout}"
 
             # Now test db-status with data
-            result = subprocess.run(
+            result = subprocess.run(  # noqa: S603
                 cmd_base
                 + [
                     "--host",
@@ -371,7 +371,7 @@ class TestCLIIntegrationSQL:
                 "--force",
             ]
 
-            load_result = subprocess.run(
+            load_result = subprocess.run(  # noqa: S603
                 load_cmd,
                 capture_output=True,
                 text=True,
@@ -426,7 +426,7 @@ class TestCLIIntegrationSQL:
                     config["password"],
                 ]
 
-                config_result = subprocess.run(
+                config_result = subprocess.run(  # noqa: S603
                     config_cmd,
                     capture_output=True,
                     text=True,
@@ -491,7 +491,7 @@ class TestCLIIntegrationSQL:
                     config["password"],
                 ]
 
-                update_result = subprocess.run(
+                update_result = subprocess.run(  # noqa: S603
                     update_cmd,
                     capture_output=True,
                     text=True,
@@ -550,7 +550,7 @@ class TestCLIIntegrationSQL:
                     config["password"],
                 ]
 
-                empty_result = subprocess.run(
+                empty_result = subprocess.run(  # noqa: S603
                     empty_cmd,
                     capture_output=True,
                     text=True,
@@ -580,7 +580,7 @@ class TestCLIIntegrationSQL:
                     config["password"],
                 ]
 
-                clear_result = subprocess.run(
+                clear_result = subprocess.run(  # noqa: S603
                     clear_prompt_cmd,
                     capture_output=True,
                     text=True,
@@ -622,7 +622,7 @@ class TestCLIIntegrationSQL:
                     config["password"],
                 ]
 
-                clear_all_result = subprocess.run(
+                clear_all_result = subprocess.run(  # noqa: S603
                     clear_all_cmd,
                     capture_output=True,
                     text=True,

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1,12 +1,15 @@
 """Integration tests for CLI commands."""
 
 import subprocess
+
 from pathlib import Path
 
 import psycopg
 import pytest
 
-from tests.test_config import get_test_db_config, should_skip_postgres_tests
+from tests.test_config import get_test_db_config
+from tests.test_config import should_skip_postgres_tests
+
 
 # Get project root directory dynamically
 PROJECT_ROOT = Path(__file__).parent.parent

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1,7 +1,6 @@
 """Integration tests for CLI commands."""
 
 import subprocess
-import time
 from pathlib import Path
 
 import psycopg
@@ -50,9 +49,7 @@ class TestCLIIntegrationSQL:
         config = get_test_db_config()
 
         try:
-            fixtures_content_dir = (
-                Path(__file__).parent / "fixtures" / "content" / "documents"
-            )
+            fixtures_content_dir = Path(__file__).parent / "fixtures" / "content" / "documents"
 
             cmd = [
                 "uv",
@@ -86,32 +83,22 @@ class TestCLIIntegrationSQL:
             )
 
             if result.returncode != 0:
-                pytest.fail(
-                    f"CLI load command failed:\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
-                )
+                pytest.fail(f"CLI load command failed:\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}")
 
             # Connect using psycopg directly
             conn_string = f"postgresql://{config['user']}:{config['password']}@{config['host']}:{config['port']}/{config['database']}"
 
             with psycopg.Connection.connect(conn_string) as conn:
                 # Check that tables were created
-                assert check_table_exists(conn, "documents"), (
-                    "documents table should be created"
-                )
-                assert check_table_exists(conn, "chunks"), (
-                    "chunks table should be created"
-                )
-                assert check_table_exists(conn, "embeddings"), (
-                    "embeddings table should be created"
-                )
+                assert check_table_exists(conn, "documents"), "documents table should be created"
+                assert check_table_exists(conn, "chunks"), "chunks table should be created"
+                assert check_table_exists(conn, "embeddings"), "embeddings table should be created"
 
                 # Check that pgvector extension was enabled
                 with conn.cursor() as cur:
                     cur.execute("SELECT '[1,2,3]'::vector")
                     vector_result = cur.fetchone()
-                    assert vector_result is not None, (
-                        "pgvector extension should be enabled"
-                    )
+                    assert vector_result is not None, "pgvector extension should be enabled"
 
                 # Check that our test data was loaded
                 doc_count = count_records(conn, "documents")
@@ -156,18 +143,14 @@ class TestCLIIntegrationSQL:
                 text=True,
                 cwd=str(PROJECT_ROOT),
             )
-            assert result.returncode == 1, (
-                "Should exit with error code when server is down"
-            )
+            assert result.returncode == 1, "Should exit with error code when server is down"
             assert "Database connection failed" in result.stdout, (
                 "Should show database connection failed when server is down"
             )
-            assert "does not exist" not in result.stdout, (
-                "Should not mention database existence when server is down"
+            assert "does not exist" not in result.stdout, "Should not mention database existence when server is down"
+            assert "Traceback" not in result.stdout and "Traceback" not in result.stderr, (
+                "Should not show traceback for expected error"
             )
-            assert (
-                "Traceback" not in result.stdout and "Traceback" not in result.stderr
-            ), "Should not show traceback for expected error"
 
             # Test 2: Server up but database doesn't exist
             result = subprocess.run(
@@ -188,15 +171,11 @@ class TestCLIIntegrationSQL:
                 text=True,
                 cwd=str(PROJECT_ROOT),
             )
-            assert result.returncode == 1, (
-                "Should exit with error when database doesn't exist"
+            assert result.returncode == 1, "Should exit with error when database doesn't exist"
+            assert "does not exist" in result.stdout, "Should show database doesn't exist error"
+            assert "Traceback" not in result.stdout and "Traceback" not in result.stderr, (
+                "Should not show traceback for expected error"
             )
-            assert "does not exist" in result.stdout, (
-                "Should show database doesn't exist error"
-            )
-            assert (
-                "Traceback" not in result.stdout and "Traceback" not in result.stderr
-            ), "Should not show traceback for expected error"
 
             # Test 3: Database exists but is not initialized
             result = subprocess.run(
@@ -218,12 +197,8 @@ class TestCLIIntegrationSQL:
                 cwd=str(PROJECT_ROOT),
             )
             # Should report that database exists but is not initialized
-            assert result.returncode == 1, (
-                "Should exit with error when database is not initialized"
-            )
-            assert "Database connection successful" in result.stdout, (
-                "Should show connection success"
-            )
+            assert result.returncode == 1, "Should exit with error when database is not initialized"
+            assert "Database connection successful" in result.stdout, "Should show connection success"
             # Should indicate that the database is not initialized (no tables exist)
             assert (
                 "not initialized" in result.stdout.lower()
@@ -285,20 +260,14 @@ class TestCLIIntegrationSQL:
                 text=True,
                 cwd=str(PROJECT_ROOT),
             )
-            assert result.returncode == 0, (
-                "Should succeed with initialized empty database"
-            )
-            assert "Database connection successful" in result.stdout, (
-                "Should show success message"
-            )
+            assert result.returncode == 0, "Should succeed with initialized empty database"
+            assert "Database connection successful" in result.stdout, "Should show success message"
             assert "documents : 0" in result.stdout, "Should show 0 documents"
             assert "chunks    : 0" in result.stdout, "Should show 0 chunks"
             assert "embeddings: 0" in result.stdout, "Should show 0 embeddings"
 
             # Test 5: Database with actual data
-            fixtures_content_dir = (
-                Path(__file__).parent / "fixtures" / "content" / "documents"
-            )
+            fixtures_content_dir = Path(__file__).parent / "fixtures" / "content" / "documents"
 
             load_result = subprocess.run(
                 [
@@ -326,9 +295,7 @@ class TestCLIIntegrationSQL:
                 cwd=str(PROJECT_ROOT),
             )
 
-            assert load_result.returncode == 0, (
-                f"Load should succeed: {load_result.stdout}"
-            )
+            assert load_result.returncode == 0, f"Load should succeed: {load_result.stdout}"
 
             # Now test db-status with data
             result = subprocess.run(
@@ -350,19 +317,17 @@ class TestCLIIntegrationSQL:
                 cwd=str(PROJECT_ROOT),
             )
             assert result.returncode == 0, "Should succeed with data in database"
-            assert "Database connection successful" in result.stdout, (
-                "Should show success message"
-            )
+            assert "Database connection successful" in result.stdout, "Should show success message"
             # Should show non-zero counts
-            assert (
-                "documents : " in result.stdout and "documents : 0" not in result.stdout
-            ), "Should show non-zero documents"
-            assert (
-                "chunks    : " in result.stdout and "chunks    : 0" not in result.stdout
-            ), "Should show non-zero chunks"
-            assert (
-                "embeddings: " in result.stdout and "embeddings: 0" not in result.stdout
-            ), "Should show non-zero embeddings"
+            assert "documents : " in result.stdout and "documents : 0" not in result.stdout, (
+                "Should show non-zero documents"
+            )
+            assert "chunks    : " in result.stdout and "chunks    : 0" not in result.stdout, (
+                "Should show non-zero chunks"
+            )
+            assert "embeddings: " in result.stdout and "embeddings: 0" not in result.stdout, (
+                "Should show non-zero embeddings"
+            )
 
         except Exception as e:
             pytest.fail(f"Test failed with exception: {e}")
@@ -377,9 +342,7 @@ class TestCLIIntegrationSQL:
 
         try:
             # First, initialize database with load command
-            fixtures_content_dir = (
-                Path(__file__).parent / "fixtures" / "content" / "documents"
-            )
+            fixtures_content_dir = Path(__file__).parent / "fixtures" / "content" / "documents"
 
             load_cmd = [
                 "uv",
@@ -412,9 +375,7 @@ class TestCLIIntegrationSQL:
                 cwd=str(PROJECT_ROOT),
             )
 
-            assert load_result.returncode == 0, (
-                f"Load command should succeed: {load_result.stderr}"
-            )
+            assert load_result.returncode == 0, f"Load command should succeed: {load_result.stderr}"
 
             # Connect to database
             conn_string = f"postgresql://{config['user']}:{config['password']}@{config['host']}:{config['port']}/{config['database']}"
@@ -469,12 +430,8 @@ class TestCLIIntegrationSQL:
                     cwd=str(PROJECT_ROOT),
                 )
 
-                assert config_result.returncode == 0, (
-                    f"Config command should succeed: {config_result.stderr}"
-                )
-                assert "RAG settings updated successfully" in config_result.stdout, (
-                    "Should show success message"
-                )
+                assert config_result.returncode == 0, f"Config command should succeed: {config_result.stderr}"
+                assert "RAG settings updated successfully" in config_result.stdout, "Should show success message"
 
                 # Verify settings were stored in database
                 with conn.cursor() as cur:
@@ -488,9 +445,7 @@ class TestCLIIntegrationSQL:
                     )
                     row = cur.fetchone()
 
-                    assert row is not None, (
-                        "Settings row should exist after config command"
-                    )
+                    assert row is not None, "Settings row should exist after config command"
 
                     (
                         refinement_prompt,
@@ -503,23 +458,13 @@ class TestCLIIntegrationSQL:
                     ) = row
 
                     # Verify each setting
-                    assert refinement_prompt == "Test custom prompt with {question}", (
-                        "Refinement prompt should match"
-                    )
-                    assert enable_refinement is False, (
-                        "enable_refinement should be False"
-                    )
+                    assert refinement_prompt == "Test custom prompt with {question}", "Refinement prompt should match"
+                    assert enable_refinement is False, "enable_refinement should be False"
                     assert enable_reranking is True, "enable_reranking should be True"
-                    assert similarity_threshold == 0.85, (
-                        "similarity_threshold should be 0.85"
-                    )
+                    assert similarity_threshold == 0.85, "similarity_threshold should be 0.85"
                     assert max_chunks == 20, "max_chunks should be 20"
-                    assert max_tokens_in_context == 8192, (
-                        "max_tokens_in_context should be 8192"
-                    )
-                    assert refinement_questions_count == 3, (
-                        "refinement_questions_count should be 3"
-                    )
+                    assert max_tokens_in_context == 8192, "max_tokens_in_context should be 8192"
+                    assert refinement_questions_count == 3, "refinement_questions_count should be 3"
 
                 # Test updating settings (partial update)
                 update_cmd = [
@@ -550,9 +495,7 @@ class TestCLIIntegrationSQL:
                     cwd=str(PROJECT_ROOT),
                 )
 
-                assert update_result.returncode == 0, (
-                    f"Config update should succeed: {update_result.stderr}"
-                )
+                assert update_result.returncode == 0, f"Config update should succeed: {update_result.stderr}"
 
                 # Verify only specified settings were updated, others remain unchanged
                 with conn.cursor() as cur:
@@ -576,18 +519,12 @@ class TestCLIIntegrationSQL:
                     ) = row
 
                     # Updated values
-                    assert enable_refinement is True, (
-                        "enable_refinement should be updated to True"
-                    )
+                    assert enable_refinement is True, "enable_refinement should be updated to True"
                     assert max_chunks == 15, "max_chunks should be updated to 15"
 
                     # Unchanged values
-                    assert enable_reranking is True, (
-                        "enable_reranking should remain True"
-                    )
-                    assert similarity_threshold == 0.85, (
-                        "similarity_threshold should remain 0.85"
-                    )
+                    assert enable_reranking is True, "enable_reranking should remain True"
+                    assert similarity_threshold == 0.85, "similarity_threshold should remain 0.85"
                     assert refinement_prompt == "Test custom prompt with {question}", (
                         "refinement_prompt should remain unchanged"
                     )
@@ -617,12 +554,8 @@ class TestCLIIntegrationSQL:
                     cwd=str(PROJECT_ROOT),
                 )
 
-                assert empty_result.returncode != 0, (
-                    "Config command should fail when no settings provided"
-                )
-                assert "No settings provided" in empty_result.stdout, (
-                    "Should show error message about no settings"
-                )
+                assert empty_result.returncode != 0, "Config command should fail when no settings provided"
+                assert "No settings provided" in empty_result.stdout, "Should show error message about no settings"
 
                 # Test clearing string settings with "None"
                 clear_prompt_cmd = [
@@ -651,20 +584,14 @@ class TestCLIIntegrationSQL:
                     cwd=str(PROJECT_ROOT),
                 )
 
-                assert clear_result.returncode == 0, (
-                    f"Config command with None should succeed: {clear_result.stderr}"
-                )
+                assert clear_result.returncode == 0, f"Config command with None should succeed: {clear_result.stderr}"
 
                 # Verify refinement_prompt was cleared (set to NULL)
                 with conn.cursor() as cur:
-                    cur.execute(
-                        "SELECT refinement_prompt FROM rag_settings WHERE id = 1"
-                    )
+                    cur.execute("SELECT refinement_prompt FROM rag_settings WHERE id = 1")
                     row = cur.fetchone()
                     assert row is not None, "Settings row should still exist"
-                    assert row[0] is None, (
-                        "refinement_prompt should be NULL after clearing with 'None'"
-                    )
+                    assert row[0] is None, "refinement_prompt should be NULL after clearing with 'None'"
 
                 # Test clearing boolean and numeric settings with "None"
                 clear_all_cmd = [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,9 @@
 """Test configuration utilities for database testing."""
 
 import os
-from typing import Dict, Optional
 
 
-def get_test_db_config() -> Dict[str, str]:
+def get_test_db_config() -> dict[str, str]:
     """Get test database configuration from environment variables or defaults.
 
     This allows tests to use completely separate credentials from production.

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -25,7 +25,7 @@ def count_records(conn, table_name: str) -> int:
     """Count records in a table."""
     try:
         with conn.cursor() as cur:
-            cur.execute(f"SELECT COUNT(*) FROM {table_name}")
+            cur.execute(f"SELECT COUNT(*) FROM {table_name}")  # noqa: S608
             result = cur.fetchone()
             return result[0] if result else 0
     except Exception:
@@ -254,7 +254,7 @@ class TestDatabaseSQL:
                 port=9999,  # Invalid port
                 db="test_db",
                 user="test_user",
-                password="test_password",
+                password="test_password",  # noqa: S106
             )
         except Exception as e:
             # Should handle connection errors gracefully

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -2,14 +2,18 @@
 
 import json
 import tempfile
+
 from pathlib import Path
 from unittest.mock import patch
 
 import psycopg
 import pytest
 
-from docs2db.database import DatabaseManager, check_database_status, load_documents
-from tests.test_config import get_test_db_config, should_skip_postgres_tests
+from docs2db.database import check_database_status
+from docs2db.database import DatabaseManager
+from docs2db.database import load_documents
+from tests.test_config import get_test_db_config
+from tests.test_config import should_skip_postgres_tests
 
 
 def create_connection():

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -15,7 +15,9 @@ from tests.test_config import get_test_db_config, should_skip_postgres_tests
 def create_connection():
     """Create a connection to the test database."""
     config = get_test_db_config()
-    conn_string = f"postgresql://{config['user']}:{config['password']}@{config['host']}:{config['port']}/{config['database']}"
+    conn_string = (
+        f"postgresql://{config['user']}:{config['password']}@{config['host']}:{config['port']}/{config['database']}"
+    )
     return psycopg.Connection.connect(conn_string)
 
 
@@ -50,7 +52,7 @@ class TestDatabaseSQL:
         if should_skip_postgres_tests():
             pytest.skip("PostgreSQL tests are disabled (TEST_SKIP_POSTGRES=1)")
 
-        with create_connection() as conn:
+        with create_connection() as conn:  # noqa: SIM117
             # Simple connectivity test
             with conn.cursor() as cur:
                 cur.execute("SELECT 1")
@@ -118,9 +120,7 @@ class TestDatabaseSQL:
 
         try:
             with create_connection() as conn:
-                doc_count_before = conn.execute(
-                    "SELECT COUNT(*) FROM documents"
-                ).fetchone()[0]
+                doc_count_before = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
         except psycopg.errors.UndefinedTable:
             doc_count_before = 0
 
@@ -139,12 +139,8 @@ class TestDatabaseSQL:
         assert success1 is True
 
         with create_connection() as conn:
-            doc_count_after = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[
-                0
-            ]
-        assert doc_count_after > doc_count_before, (
-            "First load should insert at least one document"
-        )
+            doc_count_after = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+        assert doc_count_after > doc_count_before, "First load should insert at least one document"
 
         # Second load with force=False — should skip (documents already loaded)
         success2 = load_documents(
@@ -161,12 +157,8 @@ class TestDatabaseSQL:
         assert success2 is True
 
         with create_connection() as conn:
-            doc_count_after_skip = conn.execute(
-                "SELECT COUNT(*) FROM documents"
-            ).fetchone()[0]
-        assert doc_count_after_skip == doc_count_after, (
-            "force=False should not insert additional documents"
-        )
+            doc_count_after_skip = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+        assert doc_count_after_skip == doc_count_after, "force=False should not insert additional documents"
 
         # Third load with force=True — should re-process (forced reload)
         success3 = load_documents(
@@ -333,21 +325,21 @@ class TestDatabaseSQL:
             good_dir = content_dir / "good_doc"
             good_dir.mkdir()
             good_source = good_dir / "source.json"
-            good_source.write_text(
-                json.dumps({"title": "Good Doc", "content": "Content."})
-            )
+            good_source.write_text(json.dumps({"title": "Good Doc", "content": "Content."}))
             good_chunks_file = good_dir / "chunks.json"
             good_chunks_file.write_text(
-                json.dumps({
-                    "chunks": [
-                        {
-                            "text": "Good document text for savepoint test.",
-                            "contextual_text": "Good document text for savepoint test.",
-                            "metadata": {"chunk_index": 0},
-                        }
-                    ],
-                    "model": "ibm-granite/granite-embedding-30m-english",
-                })
+                json.dumps(
+                    {
+                        "chunks": [
+                            {
+                                "text": "Good document text for savepoint test.",
+                                "contextual_text": "Good document text for savepoint test.",
+                                "metadata": {"chunk_index": 0},
+                            }
+                        ],
+                        "model": "ibm-granite/granite-embedding-30m-english",
+                    }
+                )
             )
             good_embedding_data = {"embeddings": [[0.1] * 384]}
             good_emb_file = good_dir / "gran.json"
@@ -357,21 +349,21 @@ class TestDatabaseSQL:
             bad_dir = content_dir / "bad_doc"
             bad_dir.mkdir()
             bad_source = bad_dir / "source.json"
-            bad_source.write_text(
-                json.dumps({"title": "Bad Doc", "content": "Content."})
-            )
+            bad_source.write_text(json.dumps({"title": "Bad Doc", "content": "Content."}))
             bad_chunks_file = bad_dir / "chunks.json"
             bad_chunks_file.write_text(
-                json.dumps({
-                    "chunks": [
-                        {
-                            "text": "Bad document text for savepoint test.",
-                            "contextual_text": "Bad document text for savepoint test.",
-                            "metadata": {"chunk_index": 0},
-                        }
-                    ],
-                    "model": "ibm-granite/granite-embedding-30m-english",
-                })
+                json.dumps(
+                    {
+                        "chunks": [
+                            {
+                                "text": "Bad document text for savepoint test.",
+                                "contextual_text": "Bad document text for savepoint test.",
+                                "metadata": {"chunk_index": 0},
+                            }
+                        ],
+                        "model": "ibm-granite/granite-embedding-30m-english",
+                    }
+                )
             )
             bad_embedding_data = {"embeddings": [[0.1] * 384]}
             bad_emb_file = bad_dir / "gran.json"
@@ -414,9 +406,7 @@ class TestDatabaseSQL:
                         and params
                         and "bad_doc" in str(params[0])
                     ):
-                        raise RuntimeError(
-                            "Simulated DB failure for savepoint isolation test"
-                        )
+                        raise RuntimeError("Simulated DB failure for savepoint isolation test")
                     return self._conn.execute(sql, params, *args, **kwargs)
 
                 def commit(self):
@@ -444,26 +434,20 @@ class TestDatabaseSQL:
                     "get_direct_connection",
                     side_effect=mock_get_conn,
                 ):
-                    processed, errors = db_manager.load_document_batch(
-                        files_data, content_dir, force=True
-                    )
+                    processed, errors = db_manager.load_document_batch(files_data, content_dir, force=True)
 
                 # Partial success: good_doc processed, bad_doc errored
-                assert processed > 0, (
-                    f"Expected at least one document processed, got {processed}"
-                )
+                assert processed > 0, f"Expected at least one document processed, got {processed}"
                 assert errors > 0, f"Expected at least one error, got {errors}"
 
                 # The successful document must be in the database
-                with create_connection() as conn:
+                with create_connection() as conn:  # noqa: SIM117
                     with conn.cursor() as cur:
                         cur.execute(
                             "SELECT path FROM documents WHERE path = %s",
                             (good_path,),
                         )
-                        assert cur.fetchone() is not None, (
-                            f"Good document '{good_path}' not found in documents table"
-                        )
+                        assert cur.fetchone() is not None, f"Good document '{good_path}' not found in documents table"
             finally:
                 # Clean up test documents
                 with create_connection() as conn:
@@ -506,21 +490,21 @@ class TestDatabaseSQL:
             doc_dir = content_dir / "skipcheck_doc"
             doc_dir.mkdir()
             source = doc_dir / "source.json"
-            source.write_text(
-                json.dumps({"title": "Skip Check Doc", "content": "Content."})
-            )
+            source.write_text(json.dumps({"title": "Skip Check Doc", "content": "Content."}))
             chunks_file = doc_dir / "chunks.json"
             chunks_file.write_text(
-                json.dumps({
-                    "chunks": [
-                        {
-                            "text": "Text for skip-check path test.",
-                            "contextual_text": "Text for skip-check path test.",
-                            "metadata": {"chunk_index": 0},
-                        }
-                    ],
-                    "model": "ibm-granite/granite-embedding-30m-english",
-                })
+                json.dumps(
+                    {
+                        "chunks": [
+                            {
+                                "text": "Text for skip-check path test.",
+                                "contextual_text": "Text for skip-check path test.",
+                                "metadata": {"chunk_index": 0},
+                            }
+                        ],
+                        "model": "ibm-granite/granite-embedding-30m-english",
+                    }
+                )
             )
             embedding_data = {"embeddings": [[0.1] * 384]}
             emb_file = doc_dir / "gran.json"
@@ -533,29 +517,21 @@ class TestDatabaseSQL:
 
             try:
                 # --- First load: force=True inserts the document ---
-                processed_1, errors_1 = db_manager.load_document_batch(
-                    files_data, content_dir, force=True
-                )
+                processed_1, errors_1 = db_manager.load_document_batch(files_data, content_dir, force=True)
                 assert errors_1 == 0, f"First load had unexpected errors: {errors_1}"
-                assert processed_1 == 1, (
-                    f"Expected 1 document processed on first load, got {processed_1}"
-                )
+                assert processed_1 == 1, f"Expected 1 document processed on first load, got {processed_1}"
 
                 # Verify the document is stored with a relative path
-                with create_connection() as conn:
+                with create_connection() as conn:  # noqa: SIM117
                     with conn.cursor() as cur:
                         cur.execute(
                             "SELECT path FROM documents WHERE path = %s",
                             (doc_rel_path,),
                         )
-                        assert cur.fetchone() is not None, (
-                            f"Document not found at relative path '{doc_rel_path}'"
-                        )
+                        assert cur.fetchone() is not None, f"Document not found at relative path '{doc_rel_path}'"
 
                 # --- Second load: force=False should skip (already up to date) ---
-                processed_2, errors_2 = db_manager.load_document_batch(
-                    files_data, content_dir, force=False
-                )
+                processed_2, errors_2 = db_manager.load_document_batch(files_data, content_dir, force=False)
                 assert errors_2 == 0, f"Second load had unexpected errors: {errors_2}"
                 assert processed_2 == 0, (
                     f"Expected 0 documents processed (skip), got {processed_2}. "

--- a/tests/test_db_config.py
+++ b/tests/test_db_config.py
@@ -32,7 +32,7 @@ def test_default_config(clean_env, tmp_path, monkeypatch):
     assert config["port"] == "5432"
     assert config["database"] == "ragdb"
     assert config["user"] == "postgres"
-    assert config["password"] == "postgres"
+    assert config["password"] == "postgres"  # noqa: S105
 
 
 def test_env_vars_override_defaults(clean_env, tmp_path, monkeypatch):
@@ -50,7 +50,7 @@ def test_env_vars_override_defaults(clean_env, tmp_path, monkeypatch):
     assert config["port"] == "5433"
     assert config["database"] == "production_db"
     assert config["user"] == "admin"
-    assert config["password"] == "secret123"
+    assert config["password"] == "secret123"  # noqa: S105
 
 
 def test_database_url(clean_env, tmp_path, monkeypatch):
@@ -64,7 +64,7 @@ def test_database_url(clean_env, tmp_path, monkeypatch):
     assert config["port"] == "5434"
     assert config["database"] == "mydb"
     assert config["user"] == "myuser"
-    assert config["password"] == "mypass"
+    assert config["password"] == "mypass"  # noqa: S105
 
 
 def test_database_url_postgres_scheme(clean_env, tmp_path, monkeypatch):
@@ -76,7 +76,7 @@ def test_database_url_postgres_scheme(clean_env, tmp_path, monkeypatch):
 
     assert config["host"] == "localhost"
     assert config["user"] == "user"
-    assert config["password"] == "pass"
+    assert config["password"] == "pass"  # noqa: S105
 
 
 def test_database_url_without_port(clean_env, tmp_path, monkeypatch):
@@ -153,7 +153,7 @@ services:
     config = get_db_config()
 
     assert config["user"] == "compose_user"
-    assert config["password"] == "compose_pass"
+    assert config["password"] == "compose_pass"  # noqa: S105
     assert config["database"] == "compose_db"
     assert config["port"] == "5435"
 

--- a/tests/test_db_config.py
+++ b/tests/test_db_config.py
@@ -1,9 +1,5 @@
 """Tests for database configuration."""
 
-import os
-from pathlib import Path
-from unittest.mock import mock_open, patch
-
 import pytest
 
 from docs2db.database import get_db_config
@@ -60,9 +56,7 @@ def test_env_vars_override_defaults(clean_env, tmp_path, monkeypatch):
 def test_database_url(clean_env, tmp_path, monkeypatch):
     """Test DATABASE_URL parsing."""
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setenv(
-        "DATABASE_URL", "postgresql://myuser:mypass@db.example.com:5434/mydb"
-    )
+    monkeypatch.setenv("DATABASE_URL", "postgresql://myuser:mypass@db.example.com:5434/mydb")
 
     config = get_db_config()
 
@@ -238,9 +232,7 @@ services:
     compose_file = tmp_path / "postgres-compose.yml"
     compose_file.write_text(compose_content)
 
-    monkeypatch.setenv(
-        "DATABASE_URL", "postgresql://url_user:url_pass@url.host.com/url_db"
-    )
+    monkeypatch.setenv("DATABASE_URL", "postgresql://url_user:url_pass@url.host.com/url_db")
 
     config = get_db_config()
 

--- a/tests/test_document_needs_update.py
+++ b/tests/test_document_needs_update.py
@@ -1,12 +1,10 @@
 """Tests for document_needs_update function."""
 
-import json
-from datetime import datetime, timezone
-from pathlib import Path
-
 import pytest
 
-from docs2db.ingest import document_needs_update, ingest_file, ingest_from_content
+from docs2db.ingest import document_needs_update
+from docs2db.ingest import ingest_file
+from docs2db.ingest import ingest_from_content
 
 
 @pytest.fixture
@@ -52,9 +50,7 @@ def test_document_needs_update_missing_metadata(test_content_dir):
     source_file.write_text('{"name": "test"}')
 
     # Should need update because metadata is missing (when checking timestamp)
-    assert (
-        document_needs_update(doc_path, source_timestamp="2024-01-15T10:30:00Z") is True
-    )
+    assert document_needs_update(doc_path, source_timestamp="2024-01-15T10:30:00Z") is True
 
 
 def test_document_needs_update_same_file_hash(test_content_dir, sample_html_file):
@@ -68,9 +64,7 @@ def test_document_needs_update_same_file_hash(test_content_dir, sample_html_file
     assert document_needs_update(doc_path, source_file=sample_html_file) is False
 
 
-def test_document_needs_update_different_file_hash(
-    test_content_dir, sample_html_file, tmp_path
-):
+def test_document_needs_update_different_file_hash(test_content_dir, sample_html_file, tmp_path):
     """Test that document with different file hash needs update."""
     doc_path = test_content_dir / "test_doc"
 
@@ -79,9 +73,7 @@ def test_document_needs_update_different_file_hash(
 
     # Create a modified version of the file
     modified_file = tmp_path / "modified.html"
-    modified_file.write_text(
-        "<html><body><h1>Modified</h1><p>Different content</p></body></html>"
-    )
+    modified_file.write_text("<html><body><h1>Modified</h1><p>Different content</p></body></html>")
 
     # Check with modified source file - should be True (hash differs)
     assert document_needs_update(doc_path, source_file=modified_file) is True
@@ -93,9 +85,7 @@ def test_document_needs_update_same_content_hash(test_content_dir):
     content = "<html><body><h1>Test</h1></body></html>"
 
     # Ingest from content
-    ingest_from_content(
-        content, doc_path, "test.html", source_metadata={"source_type": "test"}
-    )
+    ingest_from_content(content, doc_path, "test.html", source_metadata={"source_type": "test"})
 
     # Check with same content - should be False (hash matches)
     assert document_needs_update(doc_path, content=content) is False
@@ -107,9 +97,7 @@ def test_document_needs_update_different_content_hash(test_content_dir):
     original_content = "<html><body><h1>Original</h1></body></html>"
 
     # Ingest from content
-    ingest_from_content(
-        original_content, doc_path, "test.html", source_metadata={"source_type": "test"}
-    )
+    ingest_from_content(original_content, doc_path, "test.html", source_metadata={"source_type": "test"})
 
     # Check with different content - should be True (hash differs)
     modified_content = "<html><body><h1>Modified</h1></body></html>"
@@ -164,9 +152,7 @@ def test_document_needs_update_timestamp_but_no_stored(test_content_dir):
     )
 
     # Check with timestamp - should be True (no stored timestamp to compare)
-    assert (
-        document_needs_update(doc_path, source_timestamp="2024-01-15T10:30:00Z") is True
-    )
+    assert document_needs_update(doc_path, source_timestamp="2024-01-15T10:30:00Z") is True
 
 
 def test_document_needs_update_bytes_content(test_content_dir):
@@ -175,9 +161,7 @@ def test_document_needs_update_bytes_content(test_content_dir):
     content_bytes = b"<html><body>Test</body></html>"
 
     # Ingest from bytes content
-    ingest_from_content(
-        content_bytes, doc_path, "test.html", source_metadata={"source_type": "test"}
-    )
+    ingest_from_content(content_bytes, doc_path, "test.html", source_metadata={"source_type": "test"})
 
     # Check with same bytes content - should be False
     assert document_needs_update(doc_path, content=content_bytes) is False
@@ -187,9 +171,7 @@ def test_document_needs_update_bytes_content(test_content_dir):
     assert document_needs_update(doc_path, content=different_bytes) is True
 
 
-def test_document_needs_update_multiple_checks_all_pass(
-    test_content_dir, sample_html_file
-):
+def test_document_needs_update_multiple_checks_all_pass(test_content_dir, sample_html_file):
     """Test that document doesn't need update when all checks pass."""
     doc_path = test_content_dir / "test_doc"
     timestamp = "2024-01-15T10:30:00Z"
@@ -198,17 +180,10 @@ def test_document_needs_update_multiple_checks_all_pass(
     ingest_file(sample_html_file, doc_path, source_metadata={"modified": timestamp})
 
     # Check with both matching file and timestamp - should be False
-    assert (
-        document_needs_update(
-            doc_path, source_file=sample_html_file, source_timestamp=timestamp
-        )
-        is False
-    )
+    assert document_needs_update(doc_path, source_file=sample_html_file, source_timestamp=timestamp) is False
 
 
-def test_document_needs_update_multiple_checks_one_fails(
-    test_content_dir, sample_html_file
-):
+def test_document_needs_update_multiple_checks_one_fails(test_content_dir, sample_html_file):
     """Test that document needs update when any check fails."""
     doc_path = test_content_dir / "test_doc"
     old_timestamp = "2024-01-15T10:30:00Z"
@@ -218,12 +193,7 @@ def test_document_needs_update_multiple_checks_one_fails(
 
     # Check with matching file but different timestamp - should be True
     new_timestamp = "2024-01-16T10:30:00Z"
-    assert (
-        document_needs_update(
-            doc_path, source_file=sample_html_file, source_timestamp=new_timestamp
-        )
-        is True
-    )
+    assert document_needs_update(doc_path, source_file=sample_html_file, source_timestamp=new_timestamp) is True
 
 
 def test_document_needs_update_corrupted_metadata(test_content_dir):
@@ -240,6 +210,4 @@ def test_document_needs_update_corrupted_metadata(test_content_dir):
     meta_file.write_text("{ invalid json")
 
     # Should need update because metadata is corrupted (when checking timestamp)
-    assert (
-        document_needs_update(doc_path, source_timestamp="2024-01-15T10:30:00Z") is True
-    )
+    assert document_needs_update(doc_path, source_timestamp="2024-01-15T10:30:00Z") is True

--- a/tests/test_high_level_integration.py
+++ b/tests/test_high_level_integration.py
@@ -30,7 +30,7 @@ from tests.test_config import should_skip_postgres_tests
 def count_records(conn, table_name: str) -> int:
     """Count records in a table."""
     with conn.cursor() as cur:
-        cur.execute(f"SELECT COUNT(*) FROM {table_name}")
+        cur.execute(f"SELECT COUNT(*) FROM {table_name}")  # noqa: S608
         result = cur.fetchone()
         return result[0] if result else 0
 

--- a/tests/test_high_level_integration.py
+++ b/tests/test_high_level_integration.py
@@ -10,17 +10,21 @@ This test covers the entire workflow:
 """
 
 import json
+
 from pathlib import Path
 
 import psycopg
 import pytest
 
 from docs2db.chunks import generate_chunks
-from docs2db.database import DatabaseManager, check_database_status, load_documents
+from docs2db.database import check_database_status
+from docs2db.database import DatabaseManager
+from docs2db.database import load_documents
 from docs2db.embed import generate_embeddings
 from docs2db.exceptions import DatabaseError
 from docs2db.ingest import ingest
-from tests.test_config import get_test_db_config, should_skip_postgres_tests
+from tests.test_config import get_test_db_config
+from tests.test_config import should_skip_postgres_tests
 
 
 def count_records(conn, table_name: str) -> int:

--- a/tests/test_high_level_integration.py
+++ b/tests/test_high_level_integration.py
@@ -11,11 +11,9 @@ This test covers the entire workflow:
 
 import json
 from pathlib import Path
-from typing import Dict, Set
 
 import psycopg
 import pytest
-from psycopg.sql import SQL, Identifier
 
 from docs2db.chunks import generate_chunks
 from docs2db.database import DatabaseManager, check_database_status, load_documents
@@ -33,7 +31,7 @@ def count_records(conn, table_name: str) -> int:
         return result[0] if result else 0
 
 
-def get_document_paths(conn) -> Set[str]:
+def get_document_paths(conn) -> set[str]:
     """Get set of document paths in database."""
     with conn.cursor() as cur:
         cur.execute("SELECT path FROM documents")
@@ -50,26 +48,20 @@ class TestHighLevelIntegrationSQL:
         # Just return the temp directory - the test will handle ingestion
         return tmp_path
 
-    def get_file_set(self, directory: Path, pattern: str = "*") -> Set[str]:
+    def get_file_set(self, directory: Path, pattern: str = "*") -> set[str]:
         """Get a set of filenames matching the pattern in the directory."""
         if "**" in pattern:
             # For recursive patterns, return relative paths from the directory
-            return {
-                str(f.relative_to(directory))
-                for f in directory.glob(pattern)
-                if f.is_file()
-            }
+            return {str(f.relative_to(directory)) for f in directory.glob(pattern) if f.is_file()}
         else:
             # For non-recursive patterns, return just filenames
             return {f.name for f in directory.glob(pattern) if f.is_file()}
 
-    def get_file_mtimes(self, directory: Path, pattern: str = "*") -> Dict[str, float]:
+    def get_file_mtimes(self, directory: Path, pattern: str = "*") -> dict[str, float]:
         """Get modification times for files matching the pattern."""
-        return {
-            f.name: f.stat().st_mtime for f in directory.glob(pattern) if f.is_file()
-        }
+        return {f.name: f.stat().st_mtime for f in directory.glob(pattern) if f.is_file()}
 
-    def get_database_records(self, conn) -> Dict[str, int]:
+    def get_database_records(self, conn) -> dict[str, int]:
         """Get counts of database records."""
         return {
             "documents": count_records(conn, "documents"),
@@ -84,7 +76,9 @@ class TestHighLevelIntegrationSQL:
             pytest.skip("PostgreSQL tests are disabled (TEST_SKIP_POSTGRES=1)")
 
         config = get_test_db_config()
-        conn_string = f"postgresql://{config['user']}:{config['password']}@{config['host']}:{config['port']}/{config['database']}"
+        conn_string = (
+            f"postgresql://{config['user']}:{config['password']}@{config['host']}:{config['port']}/{config['database']}"
+        )
 
         db_manager = DatabaseManager(
             host=config["host"],
@@ -125,9 +119,7 @@ class TestHighLevelIntegrationSQL:
             assert success, "Ingestion should succeed"
 
             # Verify content directory was created with ingested files
-            assert content_dir.exists(), (
-                "Content directory should be created by ingestion"
-            )
+            assert content_dir.exists(), "Content directory should be created by ingestion"
 
             # Get the ingested source.json files (new subdirectory structure)
             initial_files = self.get_file_set(content_dir, "**/source.json")
@@ -142,35 +134,25 @@ class TestHighLevelIntegrationSQL:
         # Store the initial file set for later comparisons
         expected_json_files = initial_files.copy()
 
-        success = generate_chunks(
-            str(content_dir), "**", force=False, skip_context=True
-        )
+        success = generate_chunks(str(content_dir), "**", force=False, skip_context=True)
         assert success, "Initial chunking should succeed"
 
         # Verify chunk files were created correctly (new subdirectory structure)
         chunk_files = self.get_file_set(content_dir, "**/chunks.json")
         # For each source.json, we expect chunks.json in the same directory
-        expected_chunk_files = {
-            f.replace("source.json", "chunks.json") for f in expected_json_files
-        }
-        assert chunk_files == expected_chunk_files, (
-            f"Expected {expected_chunk_files}, got {chunk_files}"
-        )
+        expected_chunk_files = {f.replace("source.json", "chunks.json") for f in expected_json_files}
+        assert chunk_files == expected_chunk_files, f"Expected {expected_chunk_files}, got {chunk_files}"
 
         # Verify no unexpected files were created
         all_files_after_chunking = self.get_file_set(content_dir, "**/*")
         # Expected files = Docling JSONs + chunks + metadata files + README created during ingestion
         # structure: doc_dir/source.json, doc_dir/chunks.json, doc_dir/meta.json
         meta_files = {f.replace("source.json", "meta.json") for f in initial_files}
-        expected_files_after_chunking = (
-            initial_files | expected_chunk_files | meta_files | {"README.md"}
-        )
+        expected_files_after_chunking = initial_files | expected_chunk_files | meta_files | {"README.md"}
         unexpected = all_files_after_chunking - expected_files_after_chunking
         missing = expected_files_after_chunking - all_files_after_chunking
         assert all_files_after_chunking == expected_files_after_chunking, (
-            f"Unexpected files created during chunking.\n"
-            f"Unexpected files: {unexpected}\n"
-            f"Missing files: {missing}"
+            f"Unexpected files created during chunking.\nUnexpected files: {unexpected}\nMissing files: {missing}"
         )
 
         # Verify chunks content is correct
@@ -188,9 +170,7 @@ class TestHighLevelIntegrationSQL:
                 # Verify each chunk has required fields
                 for chunk in chunk_data["chunks"]:
                     assert "text" in chunk, f"Missing text in chunk from {chunk_file}"
-                    assert "metadata" in chunk, (
-                        f"Missing metadata in chunk from {chunk_file}"
-                    )
+                    assert "metadata" in chunk, f"Missing metadata in chunk from {chunk_file}"
 
         # Test initial embedding
         success = generate_embeddings(
@@ -214,18 +194,12 @@ class TestHighLevelIntegrationSQL:
             if len(chunk_data["chunks"]) > 0:
                 expected_embed_files.add(chunk_file.replace("chunks.json", "gran.json"))
 
-        assert embed_files == expected_embed_files, (
-            f"Expected {expected_embed_files}, got {embed_files}"
-        )
+        assert embed_files == expected_embed_files, f"Expected {expected_embed_files}, got {embed_files}"
 
         # Verify no unexpected files were created
         all_files_after_embedding = self.get_file_set(content_dir, "**/*")
-        expected_files_after_embedding = (
-            expected_files_after_chunking | expected_embed_files
-        )
-        assert all_files_after_embedding == expected_files_after_embedding, (
-            "Unexpected files created during embedding"
-        )
+        expected_files_after_embedding = expected_files_after_chunking | expected_embed_files
+        assert all_files_after_embedding == expected_files_after_embedding, "Unexpected files created during embedding"
 
         # Verify embeddings content is correct
         for embed_file in embed_files:
@@ -235,15 +209,11 @@ class TestHighLevelIntegrationSQL:
 
             assert "embeddings" in embed_data, f"Missing embeddings in {embed_file}"
             assert "metadata" in embed_data, f"Missing metadata in {embed_file}"
-            assert len(embed_data["embeddings"]) > 0, (
-                f"No embeddings found in {embed_file}"
-            )
+            assert len(embed_data["embeddings"]) > 0, f"No embeddings found in {embed_file}"
 
             # Verify embedding dimensions match granite model (384)
             for embedding in embed_data["embeddings"]:
-                assert len(embedding) == 384, (
-                    f"Wrong embedding dimensions in {embed_file}"
-                )
+                assert len(embedding) == 384, f"Wrong embedding dimensions in {embed_file}"
 
         success = load_documents(
             content_dir=str(content_dir),
@@ -268,12 +238,8 @@ class TestHighLevelIntegrationSQL:
             assert initial_records["documents"] == expected_doc_count, (
                 f"Expected {expected_doc_count} documents, got {initial_records['documents']}"
             )
-            assert initial_records["chunks"] > 0, (
-                f"Expected chunks > 0, got {initial_records['chunks']}"
-            )
-            assert initial_records["embeddings"] > 0, (
-                f"Expected embeddings > 0, got {initial_records['embeddings']}"
-            )
+            assert initial_records["chunks"] > 0, f"Expected chunks > 0, got {initial_records['chunks']}"
+            assert initial_records["embeddings"] > 0, f"Expected embeddings > 0, got {initial_records['embeddings']}"
             assert initial_records["chunks"] == initial_records["embeddings"], (
                 "Chunks and embeddings count should match"
             )
@@ -283,13 +249,8 @@ class TestHighLevelIntegrationSQL:
             # get_document_paths returns just filenames, so extract filenames from expected embed files
             # (only files with embeddings get loaded into the database)
             # gran.json and source.json are in same directory
-            expected_doc_names = {
-                Path(f.replace("gran.json", "source.json")).name
-                for f in expected_embed_files
-            }
-            assert doc_paths == expected_doc_names, (
-                f"Expected {expected_doc_names}, got {doc_paths}"
-            )
+            expected_doc_names = {Path(f.replace("gran.json", "source.json")).name for f in expected_embed_files}
+            assert doc_paths == expected_doc_names, f"Expected {expected_doc_names}, got {doc_paths}"
 
         # === PHASE 2: Idempotency Tests ===
 
@@ -298,16 +259,12 @@ class TestHighLevelIntegrationSQL:
         embed_mtimes_before = self.get_file_mtimes(content_dir, "gran.json")
 
         # Test chunking idempotency
-        success = generate_chunks(
-            str(content_dir), "**", force=False, skip_context=True
-        )
+        success = generate_chunks(str(content_dir), "**", force=False, skip_context=True)
         assert success, "Chunking re-run should succeed"
 
         # Verify no chunk files changed
         chunk_mtimes_after = self.get_file_mtimes(content_dir, "chunks.json")
-        assert chunk_mtimes_before == chunk_mtimes_after, (
-            "Chunk files should not change on re-run"
-        )
+        assert chunk_mtimes_before == chunk_mtimes_after, "Chunk files should not change on re-run"
 
         # Test embedding idempotency
         success = generate_embeddings(
@@ -320,9 +277,7 @@ class TestHighLevelIntegrationSQL:
 
         # Verify no embedding files changed
         embed_mtimes_after = self.get_file_mtimes(content_dir, "gran.json")
-        assert embed_mtimes_before == embed_mtimes_after, (
-            "Embedding files should not change on re-run"
-        )
+        assert embed_mtimes_before == embed_mtimes_after, "Embedding files should not change on re-run"
 
         # Test database load idempotency
         success = load_documents(
@@ -341,9 +296,7 @@ class TestHighLevelIntegrationSQL:
         # Verify no records were updated (same counts)
         with psycopg.Connection.connect(conn_string) as conn:
             records_after_rerun = self.get_database_records(conn)
-            assert initial_records == records_after_rerun, (
-                "Database records should not change on re-run"
-            )
+            assert initial_records == records_after_rerun, "Database records should not change on re-run"
 
         # === PHASE 3: Force Re-processing Test ===
 
@@ -394,18 +347,13 @@ class TestHighLevelIntegrationSQL:
                 f"Should have {expected_doc_count} documents in database"
             )
             assert final_records["embeddings"] > 0, "Should have embeddings in database"
-            assert final_records["chunks"] == final_records["embeddings"], (
-                "Chunks and embeddings should match"
-            )
+            assert final_records["chunks"] == final_records["embeddings"], "Chunks and embeddings should match"
 
             # Verify all documents with embeddings are in database
             final_doc_paths = get_document_paths(conn)
             # Only documents with embeddings get loaded into the database
             # So we should expect the same documents that have gran.json files
-            expected_final_doc_names = {
-                Path(f.replace("gran.json", "source.json")).name
-                for f in expected_embed_files
-            }
+            expected_final_doc_names = {Path(f.replace("gran.json", "source.json")).name for f in expected_embed_files}
             assert final_doc_paths == expected_final_doc_names, (
                 f"Expected {expected_final_doc_names}, got {final_doc_paths}"
             )

--- a/tests/test_schema_metadata.py
+++ b/tests/test_schema_metadata.py
@@ -27,7 +27,7 @@ def get_schema_metadata(conn):
         result = cur.fetchone()
         if result:
             columns = [desc[0] for desc in cur.description]
-            return dict(zip(columns, result, strict=False))
+            return dict(zip(columns, result))
     return None
 
 
@@ -37,7 +37,7 @@ def get_schema_changes(conn):
         cur.execute("SELECT * FROM schema_changes ORDER BY id")
         results = cur.fetchall()
         columns = [desc[0] for desc in cur.description]
-        return [dict(zip(columns, row, strict=False)) for row in results]
+        return [dict(zip(columns, row)) for row in results]
 
 
 class TestSchemaMetadata:

--- a/tests/test_schema_metadata.py
+++ b/tests/test_schema_metadata.py
@@ -1,19 +1,22 @@
 """Tests for schema metadata and change tracking."""
 
-import tempfile
 from pathlib import Path
 
 import psycopg
 import pytest
 
-from docs2db.database import DatabaseManager, load_documents
-from tests.test_config import get_test_db_config, should_skip_postgres_tests
+from docs2db.database import DatabaseManager
+from docs2db.database import load_documents
+from tests.test_config import get_test_db_config
+from tests.test_config import should_skip_postgres_tests
 
 
 def create_connection():
     """Create a connection to the test database."""
     config = get_test_db_config()
-    conn_string = f"postgresql://{config['user']}:{config['password']}@{config['host']}:{config['port']}/{config['database']}"
+    conn_string = (
+        f"postgresql://{config['user']}:{config['password']}@{config['host']}:{config['port']}/{config['database']}"
+    )
     return psycopg.Connection.connect(conn_string)
 
 
@@ -24,7 +27,7 @@ def get_schema_metadata(conn):
         result = cur.fetchone()
         if result:
             columns = [desc[0] for desc in cur.description]
-            return dict(zip(columns, result))
+            return dict(zip(columns, result, strict=False))
     return None
 
 
@@ -34,7 +37,7 @@ def get_schema_changes(conn):
         cur.execute("SELECT * FROM schema_changes ORDER BY id")
         results = cur.fetchall()
         columns = [desc[0] for desc in cur.description]
-        return [dict(zip(columns, row)) for row in results]
+        return [dict(zip(columns, row, strict=False)) for row in results]
 
 
 class TestSchemaMetadata:
@@ -113,9 +116,7 @@ class TestSchemaMetadata:
 
             assert metadata is not None
             assert metadata["title"] == "Test Database"  # Unchanged
-            assert (
-                metadata["description"] == "Test Database for First Load"
-            )  # Unchanged
+            assert metadata["description"] == "Test Database for First Load"  # Unchanged
 
             # Should now have 3 records
             assert len(changes) == 3
@@ -256,9 +257,7 @@ class TestSchemaMetadata:
             assert metadata["description"] == "Test Description"
 
             # Test update_schema_metadata
-            db_manager.update_schema_metadata(
-                conn, title="Updated DB", embedding_models_count=5
-            )
+            db_manager.update_schema_metadata(conn, title="Updated DB", embedding_models_count=5)
             conn.commit()
 
             metadata = get_schema_metadata(conn)

--- a/uv.lock
+++ b/uv.lock
@@ -463,7 +463,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cachetools", specifier = ">=6.2.6" },
+    { name = "cachetools", specifier = ">=7.1.0" },
     { name = "docling", specifier = ">=2.92.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "ibm-watsonx-ai", marker = "extra == 'watsonx'", specifier = ">=1.5.11" },
@@ -472,7 +472,7 @@ requires-dist = [
     { name = "psycopg-pool", specifier = ">=3.3.1" },
     { name = "pydantic-settings", specifier = ">=2.14.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
-    { name = "rich", specifier = ">=14.3.4" },
+    { name = "rich", specifier = ">=15.0.0" },
     { name = "structlog", specifier = ">=25.5.0" },
     { name = "torch", specifier = ">=2.7.1", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torchvision", specifier = ">=0.23.0", index = "https://download.pytorch.org/whl/cpu" },
@@ -487,12 +487,12 @@ dev = [
     { name = "ipython", specifier = ">=9.13.0" },
     { name = "pre-commit", specifier = ">=4.6.0" },
     { name = "pyright", specifier = ">=1.1.409" },
-    { name = "pytest", specifier = ">=8.4.2" },
-    { name = "pytest-cov", specifier = ">=6.3.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-httpx", specifier = ">=0.36.2" },
     { name = "pytest-randomly", specifier = ">=4.1.0" },
     { name = "pytest-sugar", specifier = ">=1.1.1" },
-    { name = "python-gitlab", specifier = ">=6.5.0" },
+    { name = "python-gitlab", specifier = ">=8.3.0" },
     { name = "ruff", specifier = ">=0.15.12" },
     { name = "tox", specifier = ">=4.53.1" },
     { name = "types-cachetools", specifier = ">=6.2.0.20260408" },


### PR DESCRIPTION
## Summary

Align ruff linting config to the canonical standard shared across docs2db, docs2db-api, and docs2db-mcp-server. Fix all violations or add targeted inline `# noqa` directives with justifications.

### Config changes (`pyproject.toml`)

- Expand `ruff.lint.select` from `["I"]` to the full 12-rule canonical set: `E, F, W, I, UP, S, B, A, C4, SIM, TID252, RUF100`
- Add `line-length = 120`
- Add `per-file-ignores` for tests: `S101` (assert), `S104` (bind 0.0.0.0) — matches all other repos
- Add isort config (single-line imports, case-insensitive ordering)

### Code fixes (22 files, -1160/+748 lines)

**Fixes applied:**
- **B904** (18 sites): Add `from None` to raises inside except blocks
- **SIM103** (2): Return condition directly instead of if/else
- **SIM108** (2): Use ternary expressions
- **SIM102** (1): Merge nested if statements
- **F841** (1): Remove unused variable
- **B007** (1): Prefix unused loop variable with `_`
- **UP**: Convert legacy `typing` imports to builtins (`list`, `dict`, `tuple`, `Optional` → `X | None`)
- **I**: Reorder imports (single-line, sorted)
- **Formatting**: `ruff format` applied across all source and test files

**Inline noqa directives (with justifications):**
- **S101** (14): Assert guards in production code — tracked in [RSPEED-3062](https://redhat.atlassian.net/browse/RSPEED-3062)
- **S603/S607** (23): `subprocess.run` calls — tracked in [RSPEED-3060](https://redhat.atlassian.net/browse/RSPEED-3060)
- **S608** (4): f-string SQL with hardcoded column names (values use params)
- **S105** (5): Hardcoded test fixture passwords in `test_db_config.py`
- **S110/SIM105** (8): Intentional try-except-pass in cleanup blocks
- **E501** (5): Long LLM prompt strings in `chunks.py`

### Testing

- All 45 tests pass (`make test`)
- `ruff check` clean
- `ruff format --check` clean

[RSPEED-3062]: https://redhat.atlassian.net/browse/RSPEED-3062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ