### PR TITLE
chore: replace assert statements with proper guards

### DIFF
--- a/src/docs2db/audit.py
+++ b/src/docs2db/audit.py
@@ -150,8 +150,10 @@ def perform_audit(
                             model_config = config
                             break
 
-                    assert model is not None  # noqa: S101  # RSPEED-3062: replace asserts with guards
-                    assert model_config is not None  # noqa: S101
+                    if model is None:
+                        raise ContentError(f"Unknown embedding model: {keyword}")
+                    if model_config is None:
+                        raise ContentError(f"Unknown embedding model config: {keyword}")
                     if chunks_file.exists() and is_embedding_stale(
                         embed_file,
                         chunks_file,

--- a/src/docs2db/chunks.py
+++ b/src/docs2db/chunks.py
@@ -27,6 +27,7 @@ from docs2db.config import settings
 from docs2db.const import CHUNKING_CONFIG
 from docs2db.const import CHUNKING_SCHEMA_VERSION
 from docs2db.const import DATABASE_SCHEMA_VERSION
+from docs2db.exceptions import ConfigurationError
 from docs2db.multiproc import BatchProcessor
 from docs2db.multiproc import setup_worker_logging
 from docs2db.utils import ensure_model_available
@@ -659,7 +660,8 @@ def generate_chunks_for_document(
 
     # Reuse LLM session if context generation is enabled
     if not skip_context:
-        assert llm_session is not None  # noqa: S101
+        if llm_session is None:
+            raise ConfigurationError("LLM session is None")
         doc_text = dl_doc.export_to_markdown()
         llm_session.set_document(doc_text)
 

--- a/src/docs2db/multiproc.py
+++ b/src/docs2db/multiproc.py
@@ -20,6 +20,8 @@ from rich.progress import TextColumn
 from rich.progress import TimeRemainingColumn
 from rich.text import Text
 
+from docs2db.exceptions import ConfigurationError
+
 
 logger = structlog.get_logger(__name__)
 
@@ -309,8 +311,10 @@ class BatchProcessor:
 
     def _prime_worker_pool(self, batches):
         """Submit initial batches to all available workers."""
-        assert isinstance(self.display, ProgressDisplay)  # noqa: S101
-        assert isinstance(self.max_workers, int)  # noqa: S101
+        if not isinstance(self.display, ProgressDisplay):
+            raise ConfigurationError("Display is not a ProgressDisplay")
+        if not isinstance(self.max_workers, int):
+            raise ConfigurationError("Max workers is not an integer")
         for worker_id in range(self.max_workers):
             self._submit_batch_to_worker(worker_id, batches)
         self.display.refresh_display()
@@ -321,8 +325,10 @@ class BatchProcessor:
         Returns True if batch was submitted.
 
         """
-        assert isinstance(self.display, ProgressDisplay)  # noqa: S101
-        assert isinstance(self.executor, ProcessPoolExecutor)  # noqa: S101
+        if not isinstance(self.display, ProgressDisplay):
+            raise ConfigurationError("Display is not a ProgressDisplay")
+        if not isinstance(self.executor, ProcessPoolExecutor):
+            raise ConfigurationError("Executor is not a ProcessPoolExecutor")
         try:
             batch = next(batches)
             self.display.set_worker_status(worker_id, f"processing {batch[0]}")
@@ -379,7 +385,8 @@ class BatchProcessor:
 
     def _process_successful_result(self, result, worker_id: int, batch):
         """Update logs and displays for a successful batch result."""
-        assert isinstance(self.display, ProgressDisplay)  # noqa: S101
+        if not isinstance(self.display, ProgressDisplay):
+            raise ConfigurationError("Display is not a ProgressDisplay")
         # Replay worker logs
         for log_entry in result["worker_logs"]:
             logger.log(
@@ -397,7 +404,8 @@ class BatchProcessor:
 
     def _process_failed_result(self, error, worker_id: int, batch):
         """Update error tracking and displays for a failed batch result."""
-        assert isinstance(self.display, ProgressDisplay)  # noqa: S101
+        if not isinstance(self.display, ProgressDisplay):
+            raise ConfigurationError("Display is not a ProgressDisplay")
 
         # Log detailed error information
         logger.error(
@@ -422,8 +430,10 @@ class BatchProcessor:
 
     def _restart_workers(self, batches):
         """Restart all workers to clear memory."""
-        assert isinstance(self.display, ProgressDisplay)  # noqa: S101
-        assert isinstance(self.executor, ProcessPoolExecutor)  # noqa: S101
+        if not isinstance(self.display, ProgressDisplay):
+            raise ConfigurationError("Display is not a ProgressDisplay")
+        if not isinstance(self.executor, ProcessPoolExecutor):
+            raise ConfigurationError("Executor is not a ProcessPoolExecutor")
         # Complete remaining futures before restart
         remaining_futures = list(self.futures.keys())
         if remaining_futures:
@@ -437,7 +447,8 @@ class BatchProcessor:
         self.futures = {}
 
         # Update worker statuses
-        assert isinstance(self.max_workers, int)  # noqa: S101
+        if not isinstance(self.max_workers, int):
+            raise ConfigurationError("Max workers is not an integer")
         for worker_id in range(self.max_workers):
             self.display.set_worker_status(worker_id, "restarted")
         self.display.refresh_display()
@@ -445,7 +456,8 @@ class BatchProcessor:
 
     def _complete_remaining_futures(self, remaining_futures):
         """Complete all remaining futures before worker restart."""
-        assert isinstance(self.display, ProgressDisplay)  # noqa: S101
+        if not isinstance(self.display, ProgressDisplay):
+            raise ConfigurationError("Display is not a ProgressDisplay")
         for future in as_completed(remaining_futures):
             if future in self.futures:
                 worker_id, batch = self.futures.pop(future)
@@ -475,7 +487,8 @@ class BatchProcessor:
 
     def _update_display(self):
         """Update the progress display."""
-        assert isinstance(self.display, ProgressDisplay)  # noqa: S101
+        if not isinstance(self.display, ProgressDisplay):
+            raise ConfigurationError("Display is not a ProgressDisplay")
         self.display.update_progress(
             completed=self.processed,
             errors=self.errors,


### PR DESCRIPTION
## Summary

Replaces all 14 `assert` statements in production code with proper `if/raise` guards, eliminating all S101 (`assert` in production) ruff violations.

**JIRA:** RSPEED-3062

> **Note:** This PR is stacked on #29 (`chore/clirunner-3060`). Please review and merge #29 first.

## Changes

### `src/docs2db/multiproc.py` (11 asserts)
- Replaced `assert isinstance(self.display, ProgressDisplay)` (7 sites) with `if not isinstance(...): raise ConfigurationError(...)`
- Replaced `assert isinstance(self.executor, ProcessPoolExecutor)` (2 sites) with `if not isinstance(...): raise ConfigurationError(...)`
- Replaced `assert isinstance(self.max_workers, int)` (2 sites) with `if not isinstance(...): raise ConfigurationError(...)`
- Added `ConfigurationError` import from `docs2db.exceptions`

### `src/docs2db/audit.py` (2 asserts)
- Replaced `assert model is not None` and `assert model_config is not None` with `if model is None: raise ContentError(...)`

### `src/docs2db/chunks.py` (1 assert)
- Replaced `assert llm_session is not None` with `if llm_session is None: raise ConfigurationError(...)`
- Added `ConfigurationError` import from `docs2db.exceptions`

## Verification

- `ruff check src/` — zero S101 violations, zero `assert` statements in production code
- `make test-ci` — 45 passed
- `make test` — all 49 tests pass