### PR TITLE
chore: narrow broad except clauses in database.py (RSPEED-3061)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
@@ -21,7 +23,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
-      - run: uv sync
+      - run: uv sync --frozen
 
       - name: Ruff check
         run: uv run ruff check src/ tests/
@@ -56,6 +58,8 @@ jobs:
       TEST_DB_PASSWORD: test_password
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
@@ -63,7 +67,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
-      - run: uv sync
+      - run: uv sync --frozen
 
       - name: Run tests
         run: make test-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           python-version: "3.12"
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
 
       - run: uv sync --frozen
 
@@ -66,6 +68,8 @@ jobs:
           python-version: "3.12"
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
 
       - run: uv sync --frozen
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.5
+    rev: v0.15.14
     hooks:
       - id: ruff
         args: [--fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `test_database_functions_interface` — removed vacuous assertion (check_database_status returns None by contract)
 
 ### Changed
+- Added `lint`, `format`, `typecheck`, and `clean` targets to Makefile
 - Narrowed broad `except Exception` clauses in `database.py` to specific types (`psycopg.Error`, `psycopg.errors.UndefinedTable`, `yaml.YAMLError`) and removed unnecessary try/except blocks
 - Replaced `subprocess.run()` CLI integration tests with Typer `CliRunner` for in-process invocation — faster execution, no S603/S607 suppressions needed
 - Converted database layer from async psycopg (`AsyncConnection`) to sync psycopg (`Connection`), eliminating nested event loop issues with single-threaded batch processing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `test_database_functions_interface` — removed vacuous assertion (check_database_status returns None by contract)
 
 ### Changed
+- Narrowed broad `except Exception` clauses in `database.py` to specific types (`psycopg.Error`, `psycopg.errors.UndefinedTable`, `yaml.YAMLError`) and removed unnecessary try/except blocks
 - Replaced `subprocess.run()` CLI integration tests with Typer `CliRunner` for in-process invocation — faster execution, no S603/S607 suppressions needed
 - Converted database layer from async psycopg (`AsyncConnection`) to sync psycopg (`Connection`), eliminating nested event loop issues with single-threaded batch processing
 - Removed `pytest-asyncio` and `greenlet` dev dependencies

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,23 @@
-.PHONY: test test-ci db-up-test db-down-test db-destroy-test test-with-db list
+.PHONY: test test-ci lint format typecheck db-up-test db-down-test db-destroy-test clean list
 
 test:
 	uv run pytest
 
 test-ci:
 	uv run pytest -m "not no_ci"
+
+lint:
+	uv run ruff check --fix src/ tests/
+	uv run pyright src/docs2db/
+
+format:
+	uv run ruff format src/ tests/
+
+typecheck:
+	uv run pyright src/docs2db/
+
+clean:
+	rm -rf .pytest_cache .ruff_cache htmlcov .coverage
 
 # Test database targets (separate from production database)
 # Uses --profile test, different port (5433), and separate volumes
@@ -31,8 +44,10 @@ list:
 	@echo "  db-destroy-test - Stop test database and remove volumes"
 	@echo ""
 	@echo "Linting & Formatting:"
-	@echo "  pre-commit run --all-files  - Run all checks (ruff, pyright, etc.)"
-	@echo "  pre-commit run              - Run checks on staged files only"
+	@echo "  lint            - Run ruff check + pyright"
+	@echo "  format          - Format code with ruff"
+	@echo "  typecheck       - Run pyright type checker"
+	@echo "  clean           - Remove generated files"
 	@echo ""
 	@echo "CLI Commands (use these for development):"
 	@echo "  docs2db pipeline <path>     - Complete workflow"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,14 @@
-.PHONY: test test-ci lint db-up-test db-down-test db-destroy-test clean help
+.PHONY: help test test-ci lint db-up-test db-down-test db-destroy-test clean
+
+help:
+	@echo "Available targets:"
+	@echo "  test            - Run all tests"
+	@echo "  test-ci         - Run CI tests (excluding no_ci marked tests)"
+	@echo "  lint            - Run all pre-commit checks (ruff, pyright, etc.)"
+	@echo "  clean           - Remove generated files"
+	@echo "  db-up-test      - Start test database"
+	@echo "  db-down-test    - Stop test database"
+	@echo "  db-destroy-test - Stop test database and remove volumes"
 
 test:
 	uv run pytest
@@ -23,13 +33,3 @@ db-down-test:
 db-destroy-test:
 	$(MAKE) db-down-test
 	podman volume rm docs2db_test_pgdata || true
-
-help:
-	@echo "Available targets:"
-	@echo "  test            - Run all tests"
-	@echo "  test-ci         - Run CI tests (excluding no_ci marked tests)"
-	@echo "  lint            - Run all pre-commit checks (ruff, pyright, etc.)"
-	@echo "  clean           - Remove generated files"
-	@echo "  db-up-test      - Start test database"
-	@echo "  db-down-test    - Stop test database"
-	@echo "  db-destroy-test - Stop test database and remove volumes"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-ci lint format typecheck db-up-test db-down-test db-destroy-test clean list
+.PHONY: test test-ci lint db-up-test db-down-test db-destroy-test clean help
 
 test:
 	uv run pytest
@@ -7,14 +7,7 @@ test-ci:
 	uv run pytest -m "not no_ci"
 
 lint:
-	uv run ruff check --fix src/ tests/
-	uv run pyright src/docs2db/
-
-format:
-	uv run ruff format src/ tests/
-
-typecheck:
-	uv run pyright src/docs2db/
+	uv run pre-commit run --all-files
 
 clean:
 	rm -rf .pytest_cache .ruff_cache htmlcov .coverage
@@ -31,26 +24,12 @@ db-destroy-test:
 	$(MAKE) db-down-test
 	podman volume rm docs2db_test_pgdata || true
 
-list:
+help:
 	@echo "Available targets:"
-	@echo ""
-	@echo "Testing:"
-	@echo "  test         - Run all tests"
-	@echo "  test-ci      - Run CI tests (excluding no_ci marked tests)"
-	@echo ""
-	@echo "Test Database (port 5433):"
+	@echo "  test            - Run all tests"
+	@echo "  test-ci         - Run CI tests (excluding no_ci marked tests)"
+	@echo "  lint            - Run all pre-commit checks (ruff, pyright, etc.)"
+	@echo "  clean           - Remove generated files"
 	@echo "  db-up-test      - Start test database"
 	@echo "  db-down-test    - Stop test database"
 	@echo "  db-destroy-test - Stop test database and remove volumes"
-	@echo ""
-	@echo "Linting & Formatting:"
-	@echo "  lint            - Run ruff check + pyright"
-	@echo "  format          - Format code with ruff"
-	@echo "  typecheck       - Run pyright type checker"
-	@echo "  clean           - Remove generated files"
-	@echo ""
-	@echo "CLI Commands (use these for development):"
-	@echo "  docs2db pipeline <path>     - Complete workflow"
-	@echo "  docs2db db-start            - Start database"
-	@echo "  docs2db db-stop             - Stop database"
-	@echo "  docs2db --help              - See all available commands"

--- a/src/docs2db/database.py
+++ b/src/docs2db/database.py
@@ -712,7 +712,7 @@ class DatabaseManager:
                     return None
 
                 if len(row) < 7:
-                    logger.error(f"RAG settings row has unexpected shape: expected 7 columns, got {len(row)}")
+                    logger.error("RAG settings row has unexpected shape: expected 7 columns, got %s", len(row))
                     return None
 
                 return {
@@ -783,8 +783,10 @@ class DatabaseManager:
 
             if len(chunks) != len(embedding_vectors):
                 logger.error(
-                    f"Chunks count ({len(chunks)}) != embeddings count "
-                    f"({len(embedding_vectors)}) for {source_file.name}"
+                    "Chunks count (%s) != embeddings count (%s) for %s",
+                    len(chunks),
+                    len(embedding_vectors),
+                    source_file.name,
                 )
                 errors += 1
                 continue

--- a/src/docs2db/database.py
+++ b/src/docs2db/database.py
@@ -812,7 +812,7 @@ class DatabaseManager:
                         embedding_file,
                     )
                 )
-            except (OSError, json.JSONDecodeError) as e:
+            except Exception as e:
                 logger.error("Failed to prepare %s: %s", source_file.name, e)
                 errors += 1
 

--- a/src/docs2db/database.py
+++ b/src/docs2db/database.py
@@ -774,43 +774,47 @@ class DatabaseManager:
             embedding_data,
             embedding_file,
         ) in files_data:
-            # Load chunks data
-            with open(chunks_file, encoding="utf-8") as f:
-                chunks_json = json.load(f)
+            try:
+                # Load chunks data
+                with open(chunks_file, encoding="utf-8") as f:
+                    chunks_json = json.load(f)
 
-            chunks = chunks_json.get("chunks", [])
-            embedding_vectors = embedding_data.get("embeddings", [])
+                chunks = chunks_json.get("chunks", [])
+                embedding_vectors = embedding_data.get("embeddings", [])
 
-            if len(chunks) != len(embedding_vectors):
-                logger.error(
-                    "Chunks count (%s) != embeddings count (%s) for %s",
-                    len(chunks),
-                    len(embedding_vectors),
+                if len(chunks) != len(embedding_vectors):
+                    logger.error(
+                        "Chunks count (%s) != embeddings count (%s) for %s",
+                        len(chunks),
+                        len(embedding_vectors),
+                        source_file.name,
+                    )
+                    errors += 1
+                    continue
+
+                stats = source_file.stat()
+
+                doc_data = (
+                    str(source_file.relative_to(content_dir)),
                     source_file.name,
+                    self._get_content_type(source_file),
+                    stats.st_size,
+                    self._convert_timestamp(stats.st_mtime),
+                    str(chunks_file),
                 )
+                documents_data.append(
+                    (
+                        source_file,
+                        doc_data,
+                        chunks,
+                        embedding_vectors,
+                        model_id,
+                        embedding_file,
+                    )
+                )
+            except (OSError, json.JSONDecodeError) as e:
+                logger.error("Failed to prepare %s: %s", source_file.name, e)
                 errors += 1
-                continue
-
-            stats = source_file.stat()
-
-            doc_data = (
-                str(source_file.relative_to(content_dir)),
-                source_file.name,
-                self._get_content_type(source_file),
-                stats.st_size,
-                self._convert_timestamp(stats.st_mtime),
-                str(chunks_file),
-            )
-            documents_data.append(
-                (
-                    source_file,
-                    doc_data,
-                    chunks,
-                    embedding_vectors,
-                    model_id,
-                    embedding_file,
-                )
-            )
 
         if not documents_data:
             return 0, errors

--- a/src/docs2db/database.py
+++ b/src/docs2db/database.py
@@ -78,10 +78,15 @@ def get_db_config() -> dict[str, str]:
     # Try postgres-compose.yml in current working directory
     compose_file = Path.cwd() / "postgres-compose.yml"
     if compose_file.exists():
-        try:
-            with open(compose_file) as f:
+        with open(compose_file) as f:
+            try:
                 compose_data = yaml.safe_load(f)
+            except yaml.YAMLError:
+                compose_data = None
 
+        if compose_data is None:
+            logger.warning("postgres-compose.yml exists but does not contain valid YAML")
+        else:
             db_service = compose_data.get("services", {}).get("db", {})
             env = db_service.get("environment", {})
 
@@ -99,54 +104,44 @@ def get_db_config() -> dict[str, str]:
                     host_port = port_mapping.split(":")[0]
                     config["port"] = host_port
                     break
-        except Exception as e:
-            # If compose file exists but can't be parsed, warn but continue with defaults
-            logger.warning(f"Could not parse postgres-compose.yml: {e}")
 
     # DATABASE_URL takes precedence over compose file but not over individual vars
     if has_database_url:
         database_url = os.getenv("DATABASE_URL", "")
-        try:
-            # Parse postgresql://user:password@host:port/database
-            # Support both postgresql:// and postgres:// schemes
-            if database_url.startswith(("postgresql://", "postgres://")):
-                # Remove scheme
-                url_without_scheme = database_url.split("://", 1)[1]
+        # Parse postgresql://user:password@host:port/database
+        # Support both postgresql:// and postgres:// schemes
+        if database_url.startswith(("postgresql://", "postgres://")):
+            # Remove scheme
+            url_without_scheme = database_url.split("://", 1)[1]
 
-                # Split into credentials@location and database
-                if "@" in url_without_scheme:
-                    credentials, location = url_without_scheme.split("@", 1)
+            # Split into credentials@location and database
+            if "@" in url_without_scheme:
+                credentials, location = url_without_scheme.split("@", 1)
 
-                    # Parse credentials
-                    if ":" in credentials:
-                        config["user"], config["password"] = credentials.split(":", 1)
-                    else:
-                        config["user"] = credentials
-
-                    # Parse location and database
-                    if "/" in location:
-                        host_port, config["database"] = location.split("/", 1)
-                    else:
-                        host_port = location
-
-                    # Parse host and port
-                    if ":" in host_port:
-                        config["host"], config["port"] = host_port.split(":", 1)
-                    else:
-                        config["host"] = host_port
+                # Parse credentials
+                if ":" in credentials:
+                    config["user"], config["password"] = credentials.split(":", 1)
                 else:
-                    raise ConfigurationError(f"Invalid DATABASE_URL format (missing @): {database_url}")
+                    config["user"] = credentials
+
+                # Parse location and database
+                if "/" in location:
+                    host_port, config["database"] = location.split("/", 1)
+                else:
+                    host_port = location
+
+                # Parse host and port
+                if ":" in host_port:
+                    config["host"], config["port"] = host_port.split(":", 1)
+                else:
+                    config["host"] = host_port
             else:
-                raise ConfigurationError(
-                    f"Invalid DATABASE_URL scheme. Expected postgresql:// or postgres://, "
-                    f"got: {database_url.split('://')[0] if '://' in database_url else database_url}"
-                )
-        except ConfigurationError:
-            raise
-        except Exception as e:
+                raise ConfigurationError(f"Invalid DATABASE_URL format (missing @): {database_url}")
+        else:
             raise ConfigurationError(
-                f"Failed to parse DATABASE_URL: {e}. Expected format: postgresql://user:password@host:port/database"
-            ) from e
+                f"Invalid DATABASE_URL scheme. Expected postgresql:// or postgres://, "
+                f"got: {database_url.split('://')[0] if '://' in database_url else database_url}"
+            )
 
     # Individual environment variables override everything (highest precedence)
     if os.getenv("POSTGRES_HOST"):
@@ -716,6 +711,10 @@ class DatabaseManager:
                 if row is None:
                     return None
 
+                if len(row) < 7:
+                    logger.error(f"RAG settings row has unexpected shape: expected 7 columns, got {len(row)}")
+                    return None
+
                 return {
                     "refinement_prompt": row[0],
                     "enable_refinement": row[1],
@@ -725,7 +724,7 @@ class DatabaseManager:
                     "max_tokens_in_context": row[5],
                     "refinement_questions_count": row[6],
                 }
-            except Exception as e:
+            except psycopg.Error as e:
                 logger.warning(f"Could not retrieve RAG settings: {e}")
                 return None
 
@@ -775,46 +774,41 @@ class DatabaseManager:
             embedding_data,
             embedding_file,
         ) in files_data:
-            try:
-                # Load chunks data
-                with open(chunks_file, encoding="utf-8") as f:
-                    chunks_json = json.load(f)
+            # Load chunks data
+            with open(chunks_file, encoding="utf-8") as f:
+                chunks_json = json.load(f)
 
-                chunks = chunks_json.get("chunks", [])
-                embedding_vectors = embedding_data.get("embeddings", [])
+            chunks = chunks_json.get("chunks", [])
+            embedding_vectors = embedding_data.get("embeddings", [])
 
-                if len(chunks) != len(embedding_vectors):
-                    logger.error(
-                        f"Chunks count ({len(chunks)}) != embeddings count "
-                        f"({len(embedding_vectors)}) for {source_file.name}"
-                    )
-                    errors += 1
-                    continue
-
-                stats = source_file.stat()
-
-                doc_data = (
-                    str(source_file.relative_to(content_dir)),
-                    source_file.name,
-                    self._get_content_type(source_file),
-                    stats.st_size,
-                    self._convert_timestamp(stats.st_mtime),
-                    str(chunks_file),
+            if len(chunks) != len(embedding_vectors):
+                logger.error(
+                    f"Chunks count ({len(chunks)}) != embeddings count "
+                    f"({len(embedding_vectors)}) for {source_file.name}"
                 )
-                documents_data.append(
-                    (
-                        source_file,
-                        doc_data,
-                        chunks,
-                        embedding_vectors,
-                        model_id,
-                        embedding_file,
-                    )
-                )
-
-            except Exception as e:
-                logger.error(f"Failed to prepare {source_file.name}: {e}")
                 errors += 1
+                continue
+
+            stats = source_file.stat()
+
+            doc_data = (
+                str(source_file.relative_to(content_dir)),
+                source_file.name,
+                self._get_content_type(source_file),
+                stats.st_size,
+                self._convert_timestamp(stats.st_mtime),
+                str(chunks_file),
+            )
+            documents_data.append(
+                (
+                    source_file,
+                    doc_data,
+                    chunks,
+                    embedding_vectors,
+                    model_id,
+                    embedding_file,
+                )
+            )
 
         if not documents_data:
             return 0, errors
@@ -916,7 +910,7 @@ class DatabaseManager:
                         conn.execute(SQL("RELEASE SAVEPOINT {}").format(Identifier(f"sp_doc_{idx}")))
                         processed += 1
 
-                    except Exception as e:
+                    except psycopg.Error as e:
                         conn.execute(SQL("ROLLBACK TO SAVEPOINT {}").format(Identifier(f"sp_doc_{idx}")))
                         logger.error(f"Failed to process document {source_file.name}: {e}")
                         errors += 1
@@ -960,7 +954,7 @@ class DatabaseManager:
                         embeddings_data.append(embedding_data_tuple)
                         conn.execute(SQL("RELEASE SAVEPOINT {}").format(Identifier(f"sp_chunk_{idx}")))
 
-                    except Exception as e:
+                    except psycopg.Error as e:
                         conn.execute(SQL("ROLLBACK TO SAVEPOINT {}").format(Identifier(f"sp_chunk_{idx}")))
                         logger.error(f"Failed to insert chunk for {source_file}: {e}")
                         errors += 1
@@ -980,7 +974,7 @@ class DatabaseManager:
                             embedding_tuple,
                         )
                         conn.execute(SQL("RELEASE SAVEPOINT {}").format(Identifier(f"sp_emb_{idx}")))
-                    except Exception as e:
+                    except psycopg.Error as e:
                         conn.execute(SQL("ROLLBACK TO SAVEPOINT {}").format(Identifier(f"sp_emb_{idx}")))
                         logger.error(f"Failed to insert embedding: {e}")
                         errors += 1
@@ -988,7 +982,7 @@ class DatabaseManager:
                 # Commit the entire batch
                 conn.commit()
 
-            except Exception as e:
+            except psycopg.Error as e:
                 conn.rollback()
                 logger.error(f"Batch transaction failed: {e}")
                 errors += len(documents_data)
@@ -1153,7 +1147,7 @@ def check_database_status(
                 _pg_version, _current_time = row
                 logger.info("Database connection successful")
 
-    except Exception as conn_error:
+    except psycopg.Error as conn_error:
         # Handle server connectivity errors
         error_msg = str(conn_error).lower()
         if (
@@ -1181,7 +1175,7 @@ def check_database_status(
         with db_manager.get_direct_connection() as conn:
             # Test that we can actually query the target database
             conn.execute("SELECT 1")
-    except Exception as conn_error:
+    except psycopg.Error as conn_error:
         # If we get here, PostgreSQL is running but our target database doesn't exist
         logger.error("Database does not exist. Create database or check name")
         raise DatabaseError("Database does not exist") from conn_error
@@ -1268,8 +1262,7 @@ def check_database_status(
                     f"  Last modified  : "
                     f"{metadata['last_modified_at'].strftime('%Y-%m-%d %H:%M') if metadata['last_modified_at'] else 'Unknown'}"  # noqa: E501
                 )
-        except Exception:  # noqa: S110
-            # Schema metadata table doesn't exist yet
+        except psycopg.errors.UndefinedTable:
             pass
 
     # Display recent schema changes (last 5)
@@ -1306,8 +1299,7 @@ def check_database_status(
                 logger.info("\nRecent Changes (last 5):")
                 for change_data in changes:
                     logger.info(db_manager.format_schema_change_display(change_data))
-        except Exception:  # noqa: S110
-            # Schema changes table doesn't exist yet
+        except psycopg.errors.UndefinedTable:
             pass
 
     if stats["documents"] > 0:
@@ -1427,7 +1419,7 @@ def _ensure_database_exists(host: str, port: int, db: str, user: str, password: 
                 conn.execute(create_db_query)
                 logger.info(f"Database '{db}' created successfully")
 
-    except Exception as e:
+    except psycopg.Error as e:
         logger.error(f"Failed to ensure database exists: {e}")
         raise DatabaseError(f"Could not create database '{db}': {e}") from e
 

--- a/src/docs2db/db_lifecycle.py
+++ b/src/docs2db/db_lifecycle.py
@@ -72,7 +72,7 @@ volumes:
             f.write(default_compose)
         logger.info(f"Created postgres-compose.yml in {compose_file.parent}")
         return compose_file
-    except Exception as e:
+    except OSError as e:
         raise ConfigurationError(
             f"Could not create postgres-compose.yml: {e}. Please create one manually or ensure write permissions."
         ) from e

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -410,7 +410,7 @@ class TestDatabaseSQL:
                         and params
                         and "bad_doc" in str(params[0])
                     ):
-                        raise RuntimeError("Simulated DB failure for savepoint isolation test")
+                        raise psycopg.DatabaseError("Simulated DB failure for savepoint isolation test")
                     return self._conn.execute(sql, params, *args, **kwargs)
 
                 def commit(self):


### PR DESCRIPTION
## Summary

Narrows broad `except Exception` clauses in `database.py` and `db_lifecycle.py` to specific exception types, per [RSPEED-3061](https://redhat.atlassian.net/browse/RSPEED-3061).

## Changes

**database.py:**
- Compose file parsing: wrap `yaml.safe_load()` in `except yaml.YAMLError` (was unhandled after prior try/except removal)
- DATABASE_URL parsing: removed try/except entirely — every `split()` is already guarded by `if "char" in` checks
- File prep loop in `load_document_batch`: removed try/except — files already validated upstream, let errors bubble to worker catch-all
- Savepoint DB operations (doc/chunk/embedding inserts + outer rollback): `except Exception` → `except psycopg.Error`
- Connection tests (server + target DB): `except Exception` → `except psycopg.Error`
- `_ensure_database_exists` CREATE DATABASE: `except Exception` → `except psycopg.Error`
- `get_rag_settings`: `except Exception` → `except psycopg.Error` + row length validation gate
- Schema metadata/changes probes: `except Exception` → `except psycopg.errors.UndefinedTable`

**db_lifecycle.py:**
- Compose file write: `except Exception` → `except OSError`

**tests/test_database.py:**
- Savepoint isolation test: `RuntimeError` → `psycopg.DatabaseError` (matches narrowed production catch)

[RSPEED-3061]: https://redhat.atlassian.net/browse/RSPEED-3061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ