### PR TITLE
chore: remove unimplemented embedding provider stubs (RSPEED-3046)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ src/docs2db/
 ├── chunks.py       # Contextual chunking with LLM (Ollama/OpenAI/WatsonX)
 ├── ingest.py       # Document ingestion via Docling
 ├── embed.py        # Embedding generation orchestration (multiprocessing)
-├── embeddings.py   # Embedding model configs (Granite, E5, Slate, etc.)
+├── embeddings.py   # Embedding model provider (Granite)
 ├── multiproc.py    # Multiprocessing batch processor utility
 ├── db_lifecycle.py # Database start/stop/destroy via Podman/Docker compose
 ├── audit.py        # Content directory auditing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `test_load_documents_parameter_validation` — removed broad exception swallowing that masked real failures
 - Fixed `test_database_functions_interface` — removed vacuous assertion (check_database_status returns None by contract)
 
+### Removed
+- Removed unimplemented embedding provider stubs (Watson/Slate, SentenceTransformer, NoInstruct, E5) — only Granite was functional
+
 ### Changed
 - Added `lint`, `format`, `typecheck`, and `clean` targets to Makefile
 - Narrowed broad `except Exception` clauses in `database.py` to specific types (`psycopg.Error`, `psycopg.errors.UndefinedTable`, `yaml.YAMLError`) and removed unnecessary try/except blocks

--- a/README.md
+++ b/README.md
@@ -99,8 +99,7 @@ docs2db db-status     # Check connection and stats
 docs2db pipeline <path>              # Complete workflow
 docs2db pipeline <path> \
   --output-file my-rag.sql \         # Custom output
-  --skip-context \                   # Skip contextual chunks (faster)
-  --model intfloat/e5-small-v2       # Different embedding model
+  --skip-context                     # Skip contextual chunks (faster)
 ```
 
 ### Individual Steps
@@ -173,7 +172,7 @@ docs2db_content/
 **Files per document:**
 - `source.json` - Ingested document in Docling JSON format
 - `chunks.json` - Text chunks (with optional LLM-generated context)
-- `gran.json` - Vector embeddings (filename varies by model: `slate.json`, `e5sm.json`, etc.)
+- `gran.json` - Vector embeddings (Granite model)
 - `meta.json` - Processing metadata and timestamps
 
 **Important:** Commit this directory to version control. It contains expensive preprocessing that can be reused across updates. Docs2DB automatically skips files that haven't changed.
@@ -181,7 +180,7 @@ docs2db_content/
 ## RAG Features
 
 - **Contextual chunks** - LLM-generated context for each chunk ([Anthropic's approach](https://www.anthropic.com/engineering/contextual-retrieval))
-- **Vector embeddings** - Multiple models: granite-30m, e5-small-v2, slate-125m, noinstruct-small
+- **Vector embeddings** - Granite 30M English model (384 dimensions)
 - **Full-text search** - PostgreSQL tsvector with GIN indexing for BM25
 - **Vector similarity** - pgvector extension with HNSW indexes
 - **Schema versioning** - Track metadata and schema changes

--- a/src/docs2db/embeddings.py
+++ b/src/docs2db/embeddings.py
@@ -361,66 +361,12 @@ class GraniteEmbeddingProvider(EmbeddingProvider):
         return all_embeddings
 
 
-class WatsonEmbeddingProvider(EmbeddingProvider):
-    """Watson embedding provider - placeholder for now."""
-
-    def generate_embeddings(self, texts: list[str]) -> list[list[float]]:
-        """Generate embeddings using Watson."""
-        # TODO: Implement based on existing WatsonEmbeddingProvider
-        raise NotImplementedError("Watson provider implementation needed")
-
-
-class SentenceTransformerProvider(EmbeddingProvider):
-    """Sentence Transformers provider - placeholder for now."""
-
-    def generate_embeddings(self, texts: list[str]) -> list[list[float]]:
-        """Generate embeddings using Sentence Transformers."""
-        # TODO: Implement based on existing SentenceTransformerProvider
-        raise NotImplementedError("Sentence Transformers provider implementation needed")
-
-
-class NoInstructEmbeddingProvider(EmbeddingProvider):
-    """NoInstruct embedding provider - placeholder for now."""
-
-    def generate_embeddings(self, texts: list[str]) -> list[list[float]]:
-        """Generate embeddings using NoInstruct model."""
-        # TODO: Implement based on existing NoInstructEmbeddingProvider
-        raise NotImplementedError("NoInstruct provider implementation needed")
-
-
-class E5EmbeddingProvider(EmbeddingProvider):
-    """E5 embedding provider - placeholder for now."""
-
-    def generate_embeddings(self, texts: list[str]) -> list[list[float]]:
-        """Generate embeddings using E5 model."""
-        # TODO: Implement based on existing E5EmbeddingProvider
-        raise NotImplementedError("E5 provider implementation needed")
-
-
 EMBEDDING_CONFIGS = {
     "ibm-granite/granite-embedding-30m-english": {
         "keyword": "gran",
         "dimensions": 384,
         "batch_size": 64,
         "cls": GraniteEmbeddingProvider,
-    },
-    "ibm/slate-125m-english-rtrvr-v2": {
-        "keyword": "slate",
-        "dimensions": 768,
-        "batch_size": 2000,
-        "cls": WatsonEmbeddingProvider,
-    },
-    "avsolatorio/NoInstruct-small-Embedding-v0": {
-        "keyword": "noins",
-        "dimensions": 384,
-        "batch_size": 32,
-        "cls": NoInstructEmbeddingProvider,
-    },
-    "intfloat/e5-small-v2": {
-        "keyword": "e5sm",
-        "dimensions": 384,
-        "batch_size": 32,
-        "cls": E5EmbeddingProvider,
     },
 }
 


### PR DESCRIPTION
## Summary

Remove four unimplemented embedding provider stubs that raised `NotImplementedError`. Only Granite was ever functional.

**Removed classes:** `WatsonEmbeddingProvider`, `SentenceTransformerProvider`, `NoInstructEmbeddingProvider`, `E5EmbeddingProvider`

## Why

- All four were placeholders from initial development — nobody requested them
- Three were registered in `EMBEDDING_CONFIGS`, meaning users could select them via `--model` and hit a runtime crash mid-pipeline
- `SentenceTransformerProvider` was additionally orphaned (not in `EMBEDDING_CONFIGS` at all)
- README showed `--model intfloat/e5-small-v2` as a working example — it would crash

## Changes

- `embeddings.py`: Delete 4 stub classes, clean `EMBEDDING_CONFIGS` to Granite-only
- `README.md`: Fix misleading multi-model claims and broken CLI example
- `AGENTS.md`: Update architecture reference
- `CHANGELOG.md`: Add entry under Removed

Closes RSPEED-3046