### PR TITLE
[RSPEED-3372] Update database configuration for local development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- `POSTGRES_USER` and `POSTGRES_PASSWORD` are now required; the compose file and database config no longer provide hardcoded default credentials
+- Removed compose file parsing from database config resolution; credentials must come from environment variables, `DATABASE_URL`, or CLI arguments
+
 - Bump runtime dependencies: docling 2.113.0, pgvector 0.5.0, structlog 26.1.0, tqdm 4.68.4, xxhash 3.8.1, ibm-watsonx-ai 1.5.14
 - Bump dev dependencies: datamodel-code-generator 0.68.1, ipython 9.15.0, pyright 1.1.411, pytest 9.1.1, ruff 0.15.21, tox 4.56.4
 - Bump CI actions: actions/checkout v7, actions/setup-python v6 (latest), astral-sh/setup-uv v8.3.2, codeql-action v4.37.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `POSTGRES_USER` and `POSTGRES_PASSWORD` are now required; the compose file and database config no longer provide hardcoded default credentials
 - Removed compose file parsing from database config resolution; credentials must come from environment variables, `DATABASE_URL`, or CLI arguments
-
 - Bump runtime dependencies: docling 2.113.0, pgvector 0.5.0, structlog 26.1.0, tqdm 4.68.4, xxhash 3.8.1, ibm-watsonx-ai 1.5.14
 - Bump dev dependencies: datamodel-code-generator 0.68.1, ipython 9.15.0, pyright 1.1.411, pytest 9.1.1, ruff 0.15.21, tox 4.56.4
 - Bump CI actions: actions/checkout v7, actions/setup-python v6 (latest), astral-sh/setup-uv v8.3.2, codeql-action v4.37.0
 - Bump build system: uv_build 0.11.28
+- Added `lint`, `format`, `typecheck`, and `clean` targets to Makefile
+- Narrowed broad `except Exception` clauses in `database.py` to specific types (`psycopg.Error`, `psycopg.errors.UndefinedTable`, `yaml.YAMLError`) and removed unnecessary try/except blocks
+- Replaced `subprocess.run()` CLI integration tests with Typer `CliRunner` for in-process invocation — faster execution, no S603/S607 suppressions needed
+- Converted database layer from async psycopg (`AsyncConnection`) to sync psycopg (`Connection`), eliminating nested event loop issues with single-threaded batch processing
+- Removed `pytest-asyncio` and `greenlet` dev dependencies
+- Bumped `ibm-watsonx-ai` minimum version to `1.5.12`
+- Constrained Renovate to keep `typer` at `<0.22.0` while `docling-slim` pins it; prevents recurring broken update PRs (#33)
 
 ### Added
 - GitHub Actions CI workflow (lint + PostgreSQL-backed test suite)
@@ -37,15 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Removed unimplemented embedding provider stubs (Watson/Slate, SentenceTransformer, NoInstruct, E5) — only Granite was functional
-
-### Changed
-- Added `lint`, `format`, `typecheck`, and `clean` targets to Makefile
-- Narrowed broad `except Exception` clauses in `database.py` to specific types (`psycopg.Error`, `psycopg.errors.UndefinedTable`, `yaml.YAMLError`) and removed unnecessary try/except blocks
-- Replaced `subprocess.run()` CLI integration tests with Typer `CliRunner` for in-process invocation — faster execution, no S603/S607 suppressions needed
-- Converted database layer from async psycopg (`AsyncConnection`) to sync psycopg (`Connection`), eliminating nested event loop issues with single-threaded batch processing
-- Removed `pytest-asyncio` and `greenlet` dev dependencies
-- Bumped `ibm-watsonx-ai` minimum version to `1.5.12`
-- Constrained Renovate to keep `typer` at `<0.22.0` while `docling-slim` pins it; prevents recurring broken update PRs (#33)
 
 ## [0.4.4] - 2026-03-16
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ Each stage can also be run individually (`ingest`, `chunk`, `embed`, `load`). Al
 1. CLI arguments: `--host`, `--port`, `--db`, `--user`, `--password`
 2. Environment variables: `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`
 3. `DATABASE_URL`: `postgresql://user:pass@host:port/database`
-4. `postgres-compose.yml` in current directory
-5. Defaults: `localhost:5432`, db=`ragdb`
+4. Defaults: `localhost:5432`, db=`ragdb`
 
 `POSTGRES_USER` and `POSTGRES_PASSWORD` have no defaults and must be provided through one of the above methods.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ Each stage can also be run individually (`ingest`, `chunk`, `embed`, `load`). Al
 2. Environment variables: `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`
 3. `DATABASE_URL`: `postgresql://user:pass@host:port/database`
 4. `postgres-compose.yml` in current directory
-5. Defaults: `localhost:5432`, user=`postgres`, password=`postgres`, db=`ragdb`
+5. Defaults: `localhost:5432`, db=`ragdb`
+
+`POSTGRES_USER` and `POSTGRES_PASSWORD` have no defaults and must be provided through one of the above methods.
 
 **Examples:**
 

--- a/postgres-compose.yml
+++ b/postgres-compose.yml
@@ -7,8 +7,8 @@ services:
     image: docker.io/pgvector/pgvector:pg17
     restart: always
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER must be set}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
       POSTGRES_DB: ragdb
     ports:
       - 127.0.0.1:5432:5432
@@ -22,8 +22,8 @@ services:
     image: docker.io/pgvector/pgvector:pg17
     restart: always
     environment:
-      POSTGRES_USER: test_user
-      POSTGRES_PASSWORD: test_password
+      POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER must be set}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
       POSTGRES_DB: test_docs2db
     ports:
       - 127.0.0.1:5433:5432

--- a/postgres-compose.yml
+++ b/postgres-compose.yml
@@ -30,7 +30,7 @@ services:
     volumes:
       - test_pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U test_user -d test_docs2db"]
+      test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER -d test_docs2db"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/postgres-compose.yml
+++ b/postgres-compose.yml
@@ -11,7 +11,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: ragdb
     ports:
-      - 5432:5432
+      - 127.0.0.1:5432:5432
     volumes:
       - pgdata:/var/lib/postgresql/data
 
@@ -26,7 +26,7 @@ services:
       POSTGRES_PASSWORD: test_password
       POSTGRES_DB: test_docs2db
     ports:
-      - 5433:5432
+      - 127.0.0.1:5433:5432
     volumes:
       - test_pgdata:/var/lib/postgresql/data
     healthcheck:

--- a/src/docs2db/database.py
+++ b/src/docs2db/database.py
@@ -120,6 +120,10 @@ def get_db_config() -> dict[str, str]:
     if os.getenv("POSTGRES_PASSWORD"):
         config["password"] = os.getenv("POSTGRES_PASSWORD", "")
 
+    required = ("user", "password")
+    if any(not config.get(value) for value in required):
+        raise ConfigurationError("Missing required database credentials: user and password must be set.")
+
     return config
 
 

--- a/src/docs2db/database.py
+++ b/src/docs2db/database.py
@@ -14,7 +14,6 @@ from typing import Any
 import psutil
 import psycopg
 import structlog
-import yaml
 
 from psycopg.sql import Identifier
 from psycopg.sql import SQL
@@ -39,8 +38,6 @@ def get_db_config() -> dict[str, str]:
     Configuration precedence (highest to lowest):
     1. Environment variables (POSTGRES_HOST, POSTGRES_PORT, etc.)
     2. DATABASE_URL environment variable
-    3. postgres-compose.yml in current working directory
-    4. Default values (localhost:5432, db=ragdb)
 
     Raises:
         ConfigurationError: If both DATABASE_URL and individual POSTGRES_* vars are set
@@ -74,37 +71,6 @@ def get_db_config() -> dict[str, str]:
         "password": "",
     }
 
-    # Try postgres-compose.yml in current working directory
-    compose_file = Path.cwd() / "postgres-compose.yml"
-    if compose_file.exists():
-        with open(compose_file) as f:
-            try:
-                compose_data = yaml.safe_load(f)
-            except yaml.YAMLError:
-                compose_data = None
-
-        if compose_data is None:
-            logger.warning("postgres-compose.yml exists but does not contain valid YAML")
-        else:
-            db_service = compose_data.get("services", {}).get("db", {})
-            env = db_service.get("environment", {})
-
-            if "POSTGRES_DB" in env:
-                config["database"] = env["POSTGRES_DB"]
-            if "POSTGRES_USER" in env:
-                config["user"] = env["POSTGRES_USER"]
-            if "POSTGRES_PASSWORD" in env:
-                config["password"] = env["POSTGRES_PASSWORD"]
-
-            # Extract port from ports mapping if available
-            ports = db_service.get("ports", [])
-            for port_mapping in ports:
-                if isinstance(port_mapping, str) and ":5432" in port_mapping:
-                    host_port = port_mapping.split(":")[0]
-                    config["port"] = host_port
-                    break
-
-    # DATABASE_URL takes precedence over compose file but not over individual vars
     if has_database_url:
         database_url = os.getenv("DATABASE_URL", "")
         # Parse postgresql://user:password@host:port/database
@@ -1589,11 +1555,11 @@ def load_documents(
         model: Embedding model name (defaults to settings.embedding_model)
         pattern: Directory pattern to match (e.g., "external/**" or "additional_documents/*")
                  Defaults to "**" which loads all documents.
-        host: Database host (auto-detected from compose file if None)
-        port: Database port (auto-detected from compose file if None)
-        db: Database name (auto-detected from compose file if None)
-        user: Database user (auto-detected from compose file if None)
-        password: Database password (auto-detected from compose file if None)
+        host: Database host (defaults to localhost if None)
+        port: Database port (defaults to 5432 if None)
+        db: Database name (defaults to ragdb if None)
+        user: Database user
+        password: Database password
         force: Force reload existing documents
         batch_size: Files per batch for each worker
 
@@ -1818,11 +1784,11 @@ def dump_database(
 
     Args:
         output_file: Output file path for the database dump
-        host: Database host (auto-detected from compose file if None)
-        port: Database port (auto-detected from compose file if None)
-        db: Database name (auto-detected from compose file if None)
-        user: Database user (auto-detected from compose file if None)
-        password: Database password (auto-detected from compose file if None)
+        host: Database host (defaults to localhost if None)
+        port: Database port (defaults to 5432 if None)
+        db: Database name (defaults to ragdb if None)
+        user: Database user
+        password: Database password
         verbose: Show pg_dump output
 
     Returns:
@@ -1907,11 +1873,11 @@ def restore_database(
 
     Args:
         input_file: Input file path for the database dump
-        host: Database host (auto-detected from compose file if None)
-        port: Database port (auto-detected from compose file if None)
-        db: Database name (auto-detected from compose file if None)
-        user: Database user (auto-detected from compose file if None)
-        password: Database password (auto-detected from compose file if None)
+        host: Database host (defaults to localhost if None)
+        port: Database port (defaults to 5432 if None)
+        db: Database name (defaults to ragdb if None)
+        user: Database user
+        password: Database password
         verbose: Show psql output
 
     Returns:

--- a/src/docs2db/database.py
+++ b/src/docs2db/database.py
@@ -40,7 +40,7 @@ def get_db_config() -> dict[str, str]:
     1. Environment variables (POSTGRES_HOST, POSTGRES_PORT, etc.)
     2. DATABASE_URL environment variable
     3. postgres-compose.yml in current working directory
-    4. Default values (localhost:5432, user=postgres, db=ragdb)
+    4. Default values (localhost:5432, db=ragdb)
 
     Raises:
         ConfigurationError: If both DATABASE_URL and individual POSTGRES_* vars are set
@@ -66,13 +66,12 @@ def get_db_config() -> dict[str, str]:
             "POSTGRES_* environment variables are set. Please use one or the other."
         )
 
-    # Start with sensible defaults
     config = {
         "host": "localhost",
         "port": "5432",
         "database": "ragdb",
-        "user": "postgres",
-        "password": "postgres",
+        "user": "",
+        "password": "",
     }
 
     # Try postgres-compose.yml in current working directory

--- a/src/docs2db/db_lifecycle.py
+++ b/src/docs2db/db_lifecycle.py
@@ -59,7 +59,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: ragdb
     ports:
-      - 5432:5432
+      - 127.0.0.1:5432:5432
     volumes:
       - pgdata:/var/lib/postgresql/data
 

--- a/src/docs2db/db_lifecycle.py
+++ b/src/docs2db/db_lifecycle.py
@@ -55,8 +55,8 @@ services:
     image: docker.io/pgvector/pgvector:pg17
     restart: always
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER must be set}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
       POSTGRES_DB: ragdb
     ports:
       - 127.0.0.1:5432:5432

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -16,6 +16,13 @@ from tests.test_config import get_test_db_config
 from tests.test_config import should_skip_postgres_tests
 
 
+@pytest.fixture(autouse=True)
+def _set_db_credentials(monkeypatch):
+    config = get_test_db_config()
+    monkeypatch.setenv("POSTGRES_USER", config["user"])
+    monkeypatch.setenv("POSTGRES_PASSWORD", config["password"])
+
+
 def create_connection():
     """Create a connection to the test database."""
     config = get_test_db_config()

--- a/tests/test_db_config.py
+++ b/tests/test_db_config.py
@@ -129,78 +129,6 @@ def test_conflict_database_url_and_env_vars(clean_env, tmp_path, monkeypatch):
         get_db_config()
 
 
-def test_compose_file_in_cwd(clean_env, tmp_path, monkeypatch):
-    """Test reading configuration from postgres-compose.yml in CWD."""
-    monkeypatch.chdir(tmp_path)
-
-    compose_content = """
-name: test-project
-
-services:
-  db:
-    image: pgvector/pgvector:pg17
-    environment:
-      POSTGRES_USER: compose_user
-      POSTGRES_PASSWORD: compose_pass
-      POSTGRES_DB: compose_db
-    ports:
-      - 5435:5432
-"""
-
-    compose_file = tmp_path / "postgres-compose.yml"
-    compose_file.write_text(compose_content)
-
-    config = get_db_config()
-
-    assert config["user"] == "compose_user"
-    assert config["password"] == "compose_pass"  # noqa: S105
-    assert config["database"] == "compose_db"
-    assert config["port"] == "5435"
-
-
-def test_compose_file_malformed(clean_env, tmp_path, monkeypatch):
-    """Test handling of malformed compose file."""
-    monkeypatch.chdir(tmp_path)
-
-    compose_file = tmp_path / "postgres-compose.yml"
-    compose_file.write_text("invalid: yaml: content: [")
-
-    # Should not raise, should use defaults and log warning
-    config = get_db_config()
-
-    # Should fall back to defaults when compose file is malformed
-    assert config["user"] == ""
-    assert config["database"] == "ragdb"
-    assert config["host"] == "localhost"
-
-
-def test_env_vars_override_compose_file(clean_env, tmp_path, monkeypatch):
-    """Test that environment variables override compose file."""
-    monkeypatch.chdir(tmp_path)
-
-    compose_content = """
-name: test-project
-
-services:
-  db:
-    environment:
-      POSTGRES_USER: compose_user
-      POSTGRES_DB: compose_db
-"""
-
-    compose_file = tmp_path / "postgres-compose.yml"
-    compose_file.write_text(compose_content)
-
-    monkeypatch.setenv("POSTGRES_USER", "env_user")
-    monkeypatch.setenv("POSTGRES_DB", "env_db")
-
-    config = get_db_config()
-
-    # Environment variables should win
-    assert config["user"] == "env_user"
-    assert config["database"] == "env_db"
-
-
 def test_partial_env_vars(clean_env, tmp_path, monkeypatch):
     """Test that partial environment variables work with defaults."""
     monkeypatch.chdir(tmp_path)
@@ -215,28 +143,14 @@ def test_partial_env_vars(clean_env, tmp_path, monkeypatch):
     assert config["user"] == ""  # Default
 
 
-def test_database_url_overrides_compose(clean_env, tmp_path, monkeypatch):
-    """Test that DATABASE_URL overrides compose file."""
+def test_database_url_takes_precedence(clean_env, tmp_path, monkeypatch):
+    """Test that DATABASE_URL works for config resolution."""
     monkeypatch.chdir(tmp_path)
-
-    compose_content = """
-name: test-project
-
-services:
-  db:
-    environment:
-      POSTGRES_USER: compose_user
-      POSTGRES_DB: compose_db
-"""
-
-    compose_file = tmp_path / "postgres-compose.yml"
-    compose_file.write_text(compose_content)
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://url_user:url_pass@url.host.com/url_db")
 
     config = get_db_config()
 
-    # DATABASE_URL should win over compose
     assert config["user"] == "url_user"
     assert config["database"] == "url_db"
     assert config["host"] == "url.host.com"

--- a/tests/test_db_config.py
+++ b/tests/test_db_config.py
@@ -31,8 +31,8 @@ def test_default_config(clean_env, tmp_path, monkeypatch):
     assert config["host"] == "localhost"
     assert config["port"] == "5432"
     assert config["database"] == "ragdb"
-    assert config["user"] == "postgres"
-    assert config["password"] == "postgres"  # noqa: S105
+    assert config["user"] == ""
+    assert config["password"] == ""
 
 
 def test_env_vars_override_defaults(clean_env, tmp_path, monkeypatch):
@@ -169,7 +169,7 @@ def test_compose_file_malformed(clean_env, tmp_path, monkeypatch):
     config = get_db_config()
 
     # Should fall back to defaults when compose file is malformed
-    assert config["user"] == "postgres"
+    assert config["user"] == ""
     assert config["database"] == "ragdb"
     assert config["host"] == "localhost"
 
@@ -212,7 +212,7 @@ def test_partial_env_vars(clean_env, tmp_path, monkeypatch):
     assert config["host"] == "custom.host.com"  # From env
     assert config["port"] == "5432"  # Default
     assert config["database"] == "ragdb"  # Default
-    assert config["user"] == "postgres"  # Default
+    assert config["user"] == ""  # Default
 
 
 def test_database_url_overrides_compose(clean_env, tmp_path, monkeypatch):

--- a/tests/test_db_config.py
+++ b/tests/test_db_config.py
@@ -21,18 +21,12 @@ def clean_env(monkeypatch):
         monkeypatch.delenv(var, raising=False)
 
 
-def test_default_config(clean_env, tmp_path, monkeypatch):
-    """Test default configuration when no config sources are available."""
-    # Change to temp directory with no compose file
+def test_default_config_exits_without_credentials(clean_env, tmp_path, monkeypatch):
+    """Test that missing user/password raises ConfigurationError."""
     monkeypatch.chdir(tmp_path)
 
-    config = get_db_config()
-
-    assert config["host"] == "localhost"
-    assert config["port"] == "5432"
-    assert config["database"] == "ragdb"
-    assert config["user"] == ""
-    assert config["password"] == ""
+    with pytest.raises(ConfigurationError, match="Missing required database credentials"):
+        get_db_config()
 
 
 def test_env_vars_override_defaults(clean_env, tmp_path, monkeypatch):
@@ -91,14 +85,12 @@ def test_database_url_without_port(clean_env, tmp_path, monkeypatch):
 
 
 def test_database_url_without_password(clean_env, tmp_path, monkeypatch):
-    """Test DATABASE_URL without password."""
+    """Test DATABASE_URL without password raises ConfigurationError."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("DATABASE_URL", "postgresql://user@localhost:5432/mydb")
 
-    config = get_db_config()
-
-    assert config["user"] == "user"
-    assert config["host"] == "localhost"
+    with pytest.raises(ConfigurationError, match="Missing required database credentials"):
+        get_db_config()
 
 
 def test_database_url_invalid_scheme(clean_env, tmp_path, monkeypatch):
@@ -129,18 +121,29 @@ def test_conflict_database_url_and_env_vars(clean_env, tmp_path, monkeypatch):
         get_db_config()
 
 
-def test_partial_env_vars(clean_env, tmp_path, monkeypatch):
-    """Test that partial environment variables work with defaults."""
+def test_partial_env_vars_exits_without_credentials(clean_env, tmp_path, monkeypatch):
+    """Test that setting only host without user/password raises ConfigurationError."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("POSTGRES_HOST", "custom.host.com")
-    # Don't set other vars
+
+    with pytest.raises(ConfigurationError, match="Missing required database credentials"):
+        get_db_config()
+
+
+def test_partial_env_vars_with_credentials(clean_env, tmp_path, monkeypatch):
+    """Test that partial environment variables work when credentials are provided."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("POSTGRES_HOST", "custom.host.com")
+    monkeypatch.setenv("POSTGRES_USER", "myuser")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "mypass")
 
     config = get_db_config()
 
-    assert config["host"] == "custom.host.com"  # From env
-    assert config["port"] == "5432"  # Default
-    assert config["database"] == "ragdb"  # Default
-    assert config["user"] == ""  # Default
+    assert config["host"] == "custom.host.com"
+    assert config["port"] == "5432"
+    assert config["database"] == "ragdb"
+    assert config["user"] == "myuser"
+    assert config["password"] == "mypass"  # noqa: S105
 
 
 def test_database_url_takes_precedence(clean_env, tmp_path, monkeypatch):

--- a/tests/test_schema_metadata.py
+++ b/tests/test_schema_metadata.py
@@ -11,6 +11,13 @@ from tests.test_config import get_test_db_config
 from tests.test_config import should_skip_postgres_tests
 
 
+@pytest.fixture(autouse=True)
+def _set_db_credentials(monkeypatch):
+    config = get_test_db_config()
+    monkeypatch.setenv("POSTGRES_USER", config["user"])
+    monkeypatch.setenv("POSTGRES_PASSWORD", config["password"])
+
+
 def create_connection():
     """Create a connection to the test database."""
     config = get_test_db_config()


### PR DESCRIPTION
## What

Do not hard code default database credentials and bind the server process to localhost.

## Why

Reduces the likelihood of unintended access to the local development database.

## How to Test

`make test`

## Checklist

- [x] Tests pass (`make test`)
- [x] Pre-commit checks pass (`uv run pre-commit run --all-files`)
- [x] Documentation updated (if applicable)
