### PR TITLE
fix: bind dev PostgreSQL to loopback (RSPEED-3361)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5] - 2026-07-21
+
+### Security
+
+- Bind dev PostgreSQL containers to loopback (`127.0.0.1`) instead of all interfaces — prevents LAN exposure on untrusted networks (RSPEED-3361)
+
 ### Added
 - GitHub Actions CI workflow (lint + PostgreSQL-backed test suite)
 - OpenSSF Scorecard workflow for security scoring
@@ -25,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `test_load_documents_force_parameter` — test now uses correct fixture layout and exercises both force=False (skip) and force=True (reload) paths
 - Fixed `test_load_documents_parameter_validation` — removed broad exception swallowing that masked real failures
 - Fixed `test_database_functions_interface` — removed vacuous assertion (check_database_status returns None by contract)
+- Fixed port parsing in `get_db_config()` to handle 3-part port mappings (`ip:host_port:container_port`) from compose files
 
 ### Removed
 - Removed unimplemented embedding provider stubs (Watson/Slate, SentenceTransformer, NoInstruct, E5) — only Granite was functional
@@ -219,7 +226,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test suite
 - Development tooling: Makefile, Docker Compose setup for PostgreSQL
 
-[Unreleased]: https://github.com/rhel-lightspeed/docs2db/compare/v0.4.3...HEAD
+[Unreleased]: https://github.com/rhel-lightspeed/docs2db/compare/v0.4.5...HEAD
+[0.4.5]: https://github.com/rhel-lightspeed/docs2db/compare/v0.4.4...v0.4.5
+[0.4.4]: https://github.com/rhel-lightspeed/docs2db/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/rhel-lightspeed/docs2db/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/rhel-lightspeed/docs2db/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/rhel-lightspeed/docs2db/compare/v0.4.0...v0.4.1

--- a/postgres-compose.yml
+++ b/postgres-compose.yml
@@ -11,7 +11,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: ragdb
     ports:
-      - 5432:5432
+      - 127.0.0.1:5432:5432
     volumes:
       - pgdata:/var/lib/postgresql/data
 
@@ -26,7 +26,7 @@ services:
       POSTGRES_PASSWORD: test_password
       POSTGRES_DB: test_docs2db
     ports:
-      - 5433:5432
+      - 127.0.0.1:5433:5432
     volumes:
       - test_pgdata:/var/lib/postgresql/data
     healthcheck:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "docs2db"
-version = "0.4.4"
+version = "0.4.5"
 description = "Repository of docling documents for RAG"
 readme = "README.md"
 authors = [{ name = "Ellis Low", email = "elow@redhat.com" }]

--- a/src/docs2db/database.py
+++ b/src/docs2db/database.py
@@ -98,11 +98,17 @@ def get_db_config() -> dict[str, str]:
                 config["password"] = env["POSTGRES_PASSWORD"]
 
             # Extract port from ports mapping if available
+            # Handles both "host_port:container_port" and "ip:host_port:container_port"
             ports = db_service.get("ports", [])
             for port_mapping in ports:
                 if isinstance(port_mapping, str) and ":5432" in port_mapping:
-                    host_port = port_mapping.split(":")[0]
-                    config["port"] = host_port
+                    parts = port_mapping.split(":")
+                    if len(parts) == 3:
+                        # ip:host_port:container_port (e.g. "127.0.0.1:5432:5432")
+                        config["port"] = parts[1]
+                    elif len(parts) == 2:
+                        # host_port:container_port (e.g. "5432:5432")
+                        config["port"] = parts[0]
                     break
 
     # DATABASE_URL takes precedence over compose file but not over individual vars

--- a/src/docs2db/db_lifecycle.py
+++ b/src/docs2db/db_lifecycle.py
@@ -59,7 +59,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: ragdb
     ports:
-      - 5432:5432
+      - 127.0.0.1:5432:5432
     volumes:
       - pgdata:/var/lib/postgresql/data
 

--- a/uv.lock
+++ b/uv.lock
@@ -427,7 +427,7 @@ standard = [
 
 [[package]]
 name = "docs2db"
-version = "0.4.4"
+version = "0.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },
@@ -2055,13 +2055,13 @@ resolution-markers = [
     "sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "sys_platform == 'darwin'" },
-    { name = "networkx", marker = "sys_platform == 'darwin'" },
-    { name = "setuptools", marker = "sys_platform == 'darwin'" },
-    { name = "sympy", marker = "sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:7fbbf409143a4fe0812a40c0b46a436030a7e1d14fe8c5234dfbe44df47f617e", upload-time = "2026-02-06T16:27:14Z" },
@@ -2078,13 +2078,13 @@ resolution-markers = [
     "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform != 'darwin'" },
-    { name = "fsspec", marker = "sys_platform != 'darwin'" },
-    { name = "jinja2", marker = "sys_platform != 'darwin'" },
-    { name = "networkx", marker = "sys_platform != 'darwin'" },
-    { name = "setuptools", marker = "sys_platform != 'darwin'" },
-    { name = "sympy", marker = "sys_platform != 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-linux_aarch64.whl", hash = "sha256:8de5a36371b775e2d4881ed12cc7f2de400b1ad3d728aa74a281f649f87c9b8c", upload-time = "2026-01-23T15:10:22Z" },
@@ -2103,9 +2103,9 @@ resolution-markers = [
     "sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'darwin'" },
-    { name = "pillow", marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.10.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://download.pytorch.org/whl/cpu" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:724f212a58a0d0d758649ce288601056b5f46a01de545702f42bccc5b25cb0cc", upload-time = "2026-01-20T18:32:31Z" },
@@ -2120,9 +2120,9 @@ resolution-markers = [
     "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform != 'darwin'" },
-    { name = "pillow", marker = "sys_platform != 'darwin'" },
-    { name = "torch", version = "2.10.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.10.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:727334e9a721cfc1ac296ce0bf9e69d9486821bfa5b1e75a8feb6f78041db481", upload-time = "2026-01-20T18:32:30Z" },


### PR DESCRIPTION
## Security Fix

Bind dev PostgreSQL containers to `127.0.0.1` instead of `0.0.0.0` to prevent LAN exposure on untrusted networks.

**Changes:**
- `postgres-compose.yml`: Both `db` and `test-db` services bound to `127.0.0.1`
- `db_lifecycle.py`: Default compose template uses loopback binding
- `database.py`: Fixed port parsing in `get_db_config()` to handle 3-part `ip:host_port:container_port` mappings
- Version bump: 0.4.4 → 0.4.5

**Audit:** ProjectGlasswing AI security audit (CVSS 3.5)

Fixes: RSPEED-3361